### PR TITLE
Making lightsaber errors visible to user

### DIFF
--- a/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
+++ b/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
@@ -41,11 +41,12 @@ import com.joom.lightsaber.processor.model.InjectionTarget
 import com.joom.lightsaber.processor.model.Module
 import com.joom.lightsaber.processor.model.ProvisionPoint
 import com.joom.lightsaber.processor.validation.DependencyResolverFactory
+import com.joom.lightsaber.processor.validation.HintsBuilder
 import com.joom.lightsaber.processor.validation.Validator
-import org.objectweb.asm.ClassReader
-import org.objectweb.asm.ClassWriter
 import java.io.Closeable
 import java.io.File
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassWriter
 
 class ClassProcessor(
   private val parameters: LightsaberParameters
@@ -87,7 +88,8 @@ class ClassProcessor(
     val analyzer = Analyzer(grip, errorReporter, parameters.projectName)
     val context = analyzer.analyze(parameters.inputs)
     val dependencyResolverFactory = DependencyResolverFactory(context)
-    Validator(grip.classRegistry, errorReporter, context, dependencyResolverFactory).validate()
+    val hintsBuilder = HintsBuilder(grip.classRegistry)
+    Validator(grip.classRegistry, errorReporter, context, dependencyResolverFactory, hintsBuilder).validate()
     checkErrors()
     return context
   }

--- a/processor/src/main/java/com/joom/lightsaber/processor/validation/HintsBuilder.kt
+++ b/processor/src/main/java/com/joom/lightsaber/processor/validation/HintsBuilder.kt
@@ -1,0 +1,45 @@
+package com.joom.lightsaber.processor.validation
+
+import com.joom.grip.ClassRegistry
+import com.joom.grip.mirrors.ClassMirror
+import com.joom.grip.mirrors.Type
+import com.joom.lightsaber.Provide
+import com.joom.lightsaber.ProvidedAs
+import com.joom.lightsaber.ProvidedBy
+import com.joom.lightsaber.processor.commons.Types
+import com.joom.lightsaber.processor.commons.rawType
+import com.joom.lightsaber.processor.model.Dependency
+import javax.inject.Inject
+
+class HintsBuilder(private val classRegistry: ClassRegistry) {
+
+  fun buildHint(dependency: Dependency): String? {
+    val mirror = dependency.type.rawType.getClassMirror() ?: return null
+
+    return when {
+      !mirror.isProvidedByAnnotationExist() -> "\n\t${dependency.type}: Using @${ProvidedAs::class.simpleName} without @${ProvidedBy::class.simpleName}. " +
+          "You must either add @${ProvidedBy::class.simpleName} annotation or " +
+          "add @${Provide::class.simpleName} method\n"
+      !mirror.isAnyInjectableConstructorExist() -> "\n\t${dependency.type}: Using @${ProvidedBy::class.simpleName} without @${Inject::class.simpleName}. " +
+          "You must either add at least one constructor with @${Inject::class.simpleName} annotation or " +
+          "add @${Provide::class.simpleName} method\n"
+
+      else -> null
+    }
+  }
+
+  private fun Type.getClassMirror(): ClassMirror? {
+    val objectType = this as? Type.Object ?: return null
+    return classRegistry.getClassMirror(objectType)
+  }
+
+  private fun ClassMirror.isAnyInjectableConstructorExist(): Boolean {
+    return constructors.any { constructor ->
+      constructor.annotations[Types.INJECT_TYPE] != null
+    }
+  }
+
+  private fun ClassMirror.isProvidedByAnnotationExist(): Boolean {
+    return annotations[Types.PROVIDED_BY_TYPE] != null
+  }
+}

--- a/processor/src/main/java/com/joom/lightsaber/processor/validation/Validator.kt
+++ b/processor/src/main/java/com/joom/lightsaber/processor/validation/Validator.kt
@@ -22,20 +22,15 @@ import com.joom.lightsaber.processor.ErrorReporter
 import com.joom.lightsaber.processor.commons.getDescription
 import com.joom.lightsaber.processor.commons.getInjectees
 import com.joom.lightsaber.processor.graph.findCycles
-import com.joom.lightsaber.processor.model.Component
-import com.joom.lightsaber.processor.model.ContractConfiguration
-import com.joom.lightsaber.processor.model.Converter
-import com.joom.lightsaber.processor.model.Dependency
-import com.joom.lightsaber.processor.model.Import
-import com.joom.lightsaber.processor.model.InjectionContext
-import com.joom.lightsaber.processor.model.InjectionTarget
+import com.joom.lightsaber.processor.model.*
 import com.joom.lightsaber.processor.reportError
 
 class Validator(
   private val classRegistry: ClassRegistry,
   private val errorReporter: ErrorReporter,
   private val context: InjectionContext,
-  private val dependencyResolverFactory: DependencyResolverFactory
+  private val dependencyResolverFactory: DependencyResolverFactory,
+  private val hintsBuilder: HintsBuilder
 ) {
 
   private val leafComponents: Collection<Component> by lazy {
@@ -54,6 +49,7 @@ class Validator(
     validateComponents()
     validateContractConfigurations()
     validateImportedContracts()
+    validateBindings()
     validateInjectionTargets()
   }
 
@@ -166,6 +162,25 @@ class Validator(
               }
             }
           }
+        }
+      }
+    }
+  }
+
+  private fun validateBindings() {
+    for (binding in context.bindings) {
+      val isResolvedByComponent = context.components.any { component ->
+        dependencyResolverFactory.getOrCreate(component).isResolved(binding.dependency)
+      }
+
+      val isResolvedByContractConfiguration = context.contractConfigurations.any { contractConfiguration ->
+        dependencyResolverFactory.getOrCreate(contractConfiguration).isResolved(binding.dependency)
+      }
+
+      if (!isResolvedByComponent && !isResolvedByContractConfiguration) {
+        errorReporter.reportError {
+          append("Invalid configuration for dependency: ${binding.ancestor.type}. ")
+          hintsBuilder.buildHint(binding.dependency)?.let(::append)
         }
       }
     }


### PR DESCRIPTION
Prints more detailed message in cases when bindings cannot be provided by injector
Supported cases: 
1. `@ProvidedAs` without `@ProvidedBy` annotation
2. `@ProvidedBy` without `@Inject` annotation