### PR TITLE
Fix JavaLightsaberPlugin and samples on Java 9 and later

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -Dfile.encoding=UTF-8
 kotlin.incremental=true
 android.useAndroidX=true
 pablo.shadow.enabled=false

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/GradleExtensions.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/GradleExtensions.kt
@@ -43,8 +43,12 @@ val SourceSetContainer.test: SourceSet
 
 val TaskContainer.compileJava: JavaCompile
   get() = getByName("compileJava") as JavaCompile
+val TaskContainer.classes: Task
+  get() = getByName("classes")
 val TaskContainer.compileTestJava: JavaCompile
   get() = getByName("compileTestJava") as JavaCompile
+val TaskContainer.testClasses: Task
+  get() = getByName("testClasses")
 
 operator fun TaskContainer.get(name: String): Task? {
   return findByName(name)

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
@@ -19,7 +19,6 @@ package com.joom.lightsaber.plugin
 import com.joom.lightsaber.processor.LightsaberParameters
 import com.joom.lightsaber.processor.LightsaberProcessor
 import com.joom.lightsaber.processor.watermark.WatermarkChecker
-import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleScriptException
 import org.gradle.api.logging.LogLevel
@@ -28,6 +27,9 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.net.URI
+import java.nio.file.FileSystems
 
 open class LightsaberTask : DefaultTask() {
   @InputFiles
@@ -59,7 +61,9 @@ open class LightsaberTask : DefaultTask() {
       inputs = backupDirs.map { it.toPath() },
       outputs = classesDirs.map { it.toPath() },
       classpath = classpath.map { it.toPath() },
-      bootClasspath = bootClasspath.map { it.toPath() },
+      bootClasspath = bootClasspath.map { it.toPath() }.ifEmpty {
+        listOfNotNull(FileSystems.getFileSystem(URI.create("jrt:/"))?.getPath("modules", "java.base"))
+      },
       gen = classesDirs[0].toPath(),
       projectName = name.orEmpty().replace(":lightsaberProcess", ":").replace(':', '$')
     )

--- a/samples/sample-java/build.gradle
+++ b/samples/sample-java/build.gradle
@@ -15,7 +15,7 @@ jar {
   destinationDirectory.set(file('build/jar'))
 
   from {
-    configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+    configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
   }
 }
 

--- a/samples/sample-kotlin/build.gradle
+++ b/samples/sample-kotlin/build.gradle
@@ -22,6 +22,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 
 jar {
   destinationDirectory.set(file('build/jar'))
+  duplicatesStrategy DuplicatesStrategy.EXCLUDE
 
   from {
     configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }


### PR DESCRIPTION
* Fixes empty `bootClasspath` for Java 9 and later.
* Fixes samples not compiling for Java 11 and later.
* Fixes Gradle warnings regarding "disabled optimisations" when using `JavaLightsaberPlugin`.