### PR TITLE
Fix Gradle configuration cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: ./gradlew -p lightsaber check publishToMavenLocal -Ppablo.shadow.enabled=true ${{ env.PABLO_OPTS }}
 
       - name: Run unit tests
-        run: ./gradlew check -Pdevelopment=false --stacktrace
+        run: ./gradlew check -Pdevelopment=false -Dorg.gradle.unsafe.configuration-cache=true --stacktrace
 
   test:
     name: Test
@@ -65,7 +65,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
-          script: ./gradlew connectedCheck -Pdevelopment=false
+          script: ./gradlew connectedCheck -Dorg.gradle.unsafe.configuration-cache=true -Pdevelopment=false
 
   publish:
     name: Publish

--- a/lightsaber/gradle-plugin/build.gradle
+++ b/lightsaber/gradle-plugin/build.gradle
@@ -50,6 +50,12 @@ tasks.matching { it instanceof AbstractCompile }.forEach {
   it.dependsOn tasks.generateBuildClass
 }
 
+project.afterEvaluate {
+  tasks.named(sourceSets.main.getSourcesJarTaskName()).configure {
+    it.dependsOn tasks.generateBuildClass
+  }
+}
+
 clean.doFirst {
   delete generatedDir
 }

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
@@ -49,6 +49,8 @@ open class LightsaberTask : DefaultTask() {
   @Classpath
   var bootClasspath: List<File> = emptyList()
 
+  private val projectName = formatProjectName()
+
   init {
     logging.captureStandardOutput(LogLevel.INFO)
   }
@@ -66,7 +68,7 @@ open class LightsaberTask : DefaultTask() {
         listOfNotNull(FileSystems.getFileSystem(URI.create("jrt:/"))?.getPath("modules", "java.base"))
       },
       gen = classesDirs[0].toPath(),
-      projectName = formatProjectName(),
+      projectName = projectName,
     )
 
     logger.info("Starting Lightsaber processor: {}", parameters)

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
@@ -53,6 +53,8 @@ abstract class LightsaberTransformTask : DefaultTask() {
   @get:OutputDirectory
   abstract val outputDirectory: DirectoryProperty
 
+  private val projectName = formatProjectName()
+
   init {
     logging.captureStandardOutput(LogLevel.LIFECYCLE)
   }
@@ -67,7 +69,7 @@ abstract class LightsaberTransformTask : DefaultTask() {
       bootClasspath = bootClasspath.map { it.toPath() },
       modulesClasspath = modulesClasspath.map { it.toPath() },
       gen = output,
-      projectName = formatProjectName(),
+      projectName = projectName,
     )
 
     logger.info("Starting Lightsaber processor: {}", parameters)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 def isDevelopment = properties['development'].toBoolean()
 
-includeBuild('lightsaber') {
-  if (isDevelopment) {
+if (isDevelopment) {
+  includeBuild('lightsaber') {
     dependencySubstitution {
       substitute module('com.joom.lightsaber:lightsaber-core') using project(':core')
       substitute module('com.joom.lightsaber:lightsaber-core-kotlin') using project(':core-kotlin')


### PR DESCRIPTION
This PR fixes Gradle configuration cache issue:
* Usage of `Task.getProject()` during task execution.

