### PR TITLE
Shared Grip cache and Analyzer performance improvements

### DIFF
--- a/gradle/common.gradle
+++ b/gradle/common.gradle
@@ -9,7 +9,7 @@ ext.pabloVersion = '1.3.1'
 ext.javaxInjectVersion = '1'
 ext.jsr305Version = '3.0.2'
 ext.asmVersion = '9.2'
-ext.gripVersion = '0.9.0'
+ext.gripVersion = '0.9.1'
 ext.bimapVersion = '1.1.0'
 ext.logbackVersion = '1.2.11'
 

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AndroidLightsaberPlugin.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AndroidLightsaberPlugin.kt
@@ -113,11 +113,11 @@ class AndroidLightsaberPlugin : BaseLightsaberPlugin() {
   }
 
   private fun classpathProvider(configuration: Provider<Configuration>): Provider<FileCollection> {
-    return configuration.map { it.incomingJarArtifacts().artifactFiles }
+    return configuration.map { it.incomingAndroidJarArtifacts().artifactFiles }
   }
 
   private fun modulesClasspathProvider(configuration: Provider<Configuration>): Provider<FileCollection> {
-    return configuration.map { it.incomingJarArtifacts { it is ProjectComponentIdentifier }.artifactFiles }
+    return configuration.map { it.incomingAndroidJarArtifacts { it is ProjectComponentIdentifier }.artifactFiles }
   }
 
   private operator fun Provider<FileCollection>.minus(other: Provider<FileCollection>): Provider<FileCollection> {

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AndroidLightsaberPluginExtension.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AndroidLightsaberPluginExtension.kt
@@ -3,6 +3,7 @@ package com.joom.lightsaber.plugin
 import java.io.File
 
 open class AndroidLightsaberPluginExtension {
+  var validateUsage: Boolean = true
   var cacheable: Boolean = false
   var bootClasspath: List<File> = emptyList()
 }

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/GradleExtensions.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/GradleExtensions.kt
@@ -74,12 +74,12 @@ inline fun <reified T : Task> Project.registerTask(name: String): TaskProvider<T
   return tasks.register(name, T::class.java)
 }
 
-fun Configuration.incomingJarArtifacts(componentFilter: ((ComponentIdentifier) -> Boolean)? = null): ArtifactCollection {
+fun Configuration.incomingArtifacts(artifactType: String, componentFilter: ((ComponentIdentifier) -> Boolean)?): ArtifactCollection {
   return incoming
     .artifactView { configuration ->
       configuration.attributes { attributes ->
         @Suppress("UnstableApiUsage")
-        attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, AndroidArtifacts.ArtifactType.CLASSES_JAR.type)
+        attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, artifactType)
       }
 
       componentFilter?.let {
@@ -87,6 +87,14 @@ fun Configuration.incomingJarArtifacts(componentFilter: ((ComponentIdentifier) -
       }
     }
     .artifacts
+}
+
+fun Configuration.incomingAndroidJarArtifacts(componentFilter: ((ComponentIdentifier) -> Boolean)? = null): ArtifactCollection {
+  return incomingArtifacts(AndroidArtifacts.ArtifactType.CLASSES_JAR.type, componentFilter)
+}
+
+fun Configuration.incomingJarArtifacts(componentFilter: ((ComponentIdentifier) -> Boolean)? = null): ArtifactCollection {
+  return incomingArtifacts(ArtifactTypeDefinition.JAR_TYPE, componentFilter)
 }
 
 fun Task.formatProjectName(): String {

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/JavaLightsaberPluginExtension.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/JavaLightsaberPluginExtension.kt
@@ -18,4 +18,5 @@ package com.joom.lightsaber.plugin
 
 open class JavaLightsaberPluginExtension {
   var processTest: Boolean = true
+  var validateUsage: Boolean = true
 }

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberSharedBuildCacheService.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberSharedBuildCacheService.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.plugin
+
+import com.joom.lightsaber.processor.LightsaberSharedBuildCache
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.OperationCompletionListener
+import org.gradle.tooling.events.task.TaskFinishEvent
+import java.util.Collections
+
+@Suppress("UnstableApiUsage")
+abstract class LightsaberSharedBuildCacheService : BuildService<LightsaberSharedBuildCacheService.Parameters>, AutoCloseable, OperationCompletionListener {
+  val cache = LightsaberSharedBuildCache.create()
+  private val registeredTaskPaths = Collections.synchronizedSet(HashSet<String>(parameters.taskPaths.get()))
+
+  override fun onFinish(event: FinishEvent) {
+    if (event !is TaskFinishEvent) {
+      return
+    }
+
+    val path = event.descriptor.taskPath
+    val pathRemoved = registeredTaskPaths.remove(path)
+
+    if (pathRemoved && registeredTaskPaths.size == 0) {
+      cache.close()
+    }
+  }
+
+  override fun close() {
+    registeredTaskPaths.clear()
+    cache.close()
+  }
+
+  interface Parameters : BuildServiceParameters {
+    val taskPaths: Property<Collection<String>>
+  }
+}
+

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
@@ -22,17 +22,16 @@ import com.joom.lightsaber.processor.watermark.WatermarkChecker
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleScriptException
 import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import java.io.File
 import java.net.URI
 import java.nio.file.FileSystems
 
@@ -58,6 +57,10 @@ abstract class LightsaberTask : DefaultTask() {
   @get:InputFiles
   @get:CompileClasspath
   abstract val bootClasspath: ConfigurableFileCollection
+
+  @get:Internal
+  @Suppress("UnstableApiUsage")
+  abstract val sharedBuildCacheService: Property<LightsaberSharedBuildCacheService>
 
   private val projectName = formatProjectName()
 

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
@@ -27,6 +27,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.OutputDirectory
@@ -37,6 +38,7 @@ import java.nio.file.FileSystems
 
 abstract class LightsaberTask : DefaultTask() {
   @get:InputFiles
+  @get:Classpath
   abstract val backupDirs: ConfigurableFileCollection
 
   @get:OutputDirectories
@@ -46,15 +48,15 @@ abstract class LightsaberTask : DefaultTask() {
   abstract val sourceDir: DirectoryProperty
 
   @get:InputFiles
-  @get:Classpath
+  @get:CompileClasspath
   abstract val classpath: ConfigurableFileCollection
 
   @get:InputFiles
-  @get:Classpath
+  @get:CompileClasspath
   abstract val modulesClasspath: ConfigurableFileCollection
 
   @get:InputFiles
-  @get:Classpath
+  @get:CompileClasspath
   abstract val bootClasspath: ConfigurableFileCollection
 
   private val projectName = formatProjectName()

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
@@ -21,6 +21,10 @@ import com.joom.lightsaber.processor.LightsaberProcessor
 import com.joom.lightsaber.processor.watermark.WatermarkChecker
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleScriptException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.InputFiles
@@ -31,23 +35,27 @@ import java.io.File
 import java.net.URI
 import java.nio.file.FileSystems
 
-open class LightsaberTask : DefaultTask() {
-  @InputFiles
-  var backupDirs: List<File> = emptyList()
+abstract class LightsaberTask : DefaultTask() {
+  @get:InputFiles
+  abstract val backupDirs: ConfigurableFileCollection
 
-  @OutputDirectories
-  var classesDirs: List<File> = emptyList()
+  @get:OutputDirectories
+  abstract val classesDirs: ConfigurableFileCollection
 
-  @OutputDirectory
-  var sourceDir: File? = null
+  @get:OutputDirectory
+  abstract val sourceDir: DirectoryProperty
 
-  @InputFiles
-  @Classpath
-  var classpath: List<File> = emptyList()
+  @get:InputFiles
+  @get:Classpath
+  abstract val classpath: ConfigurableFileCollection
 
-  @InputFiles
-  @Classpath
-  var bootClasspath: List<File> = emptyList()
+  @get:InputFiles
+  @get:Classpath
+  abstract val modulesClasspath: ConfigurableFileCollection
+
+  @get:InputFiles
+  @get:Classpath
+  abstract val bootClasspath: ConfigurableFileCollection
 
   private val projectName = formatProjectName()
 
@@ -63,11 +71,11 @@ open class LightsaberTask : DefaultTask() {
       inputs = backupDirs.map { it.toPath() },
       outputs = classesDirs.map { it.toPath() },
       classpath = classpath.map { it.toPath() },
-      modulesClasspath = classpath.map { it.toPath() },
+      modulesClasspath = modulesClasspath.map { it.toPath() },
       bootClasspath = bootClasspath.map { it.toPath() }.ifEmpty {
         listOfNotNull(FileSystems.getFileSystem(URI.create("jrt:/"))?.getPath("modules", "java.base"))
       },
-      gen = classesDirs[0].toPath(),
+      gen = classesDirs.first().toPath(),
       projectName = projectName,
     )
 
@@ -104,17 +112,17 @@ open class LightsaberTask : DefaultTask() {
       }
     }
 
-    sourceDir?.let { sourceDir ->
+    if (sourceDir.isPresent) {
       logger.info("Removing a directory with generated source files: {}", sourceDir)
-      sourceDir.deleteRecursively()
+      sourceDir.get().asFile.deleteRecursively()
     }
   }
 
   private fun validate() {
-    require(classesDirs.isNotEmpty()) { "classesDirs is not set" }
-    require(backupDirs.isNotEmpty()) { "backupDirs is not set" }
-    require(classesDirs.size == backupDirs.size) { "classesDirs and backupDirs must have equal size" }
-    requireNotNull(sourceDir) { "sourceDir is not set" }
+    require(!classesDirs.isEmpty) { "classesDirs is not set" }
+    require(!backupDirs.isEmpty) { "backupDirs is not set" }
+    require(classesDirs.files.size == backupDirs.files.size) { "classesDirs and backupDirs must have equal size" }
+    require(sourceDir.isPresent) { "sourceDir is not set" }
   }
 
   companion object {

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
@@ -27,6 +27,7 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.CompileClasspath
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectories
@@ -62,6 +63,9 @@ abstract class LightsaberTask : DefaultTask() {
   @Suppress("UnstableApiUsage")
   abstract val sharedBuildCacheService: Property<LightsaberSharedBuildCacheService>
 
+  @get:Input
+  abstract val validateUsage: Property<Boolean>
+
   private val projectName = formatProjectName()
 
   init {
@@ -83,6 +87,7 @@ abstract class LightsaberTask : DefaultTask() {
       gen = classesDirs.first().toPath(),
       projectName = projectName,
       sharedBuildCache = sharedBuildCacheService.get().cache,
+      validateUsage = validateUsage.get(),
     )
 
     logger.info("Starting Lightsaber processor: {}", parameters)

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
@@ -82,6 +82,7 @@ abstract class LightsaberTask : DefaultTask() {
       },
       gen = classesDirs.first().toPath(),
       projectName = projectName,
+      sharedBuildCache = sharedBuildCacheService.get().cache,
     )
 
     logger.info("Starting Lightsaber processor: {}", parameters)

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransform.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransform.kt
@@ -69,6 +69,7 @@ class LightsaberTransform(
       modulesClasspath = emptyList(),
       bootClasspath = extension.bootClasspath.map { it.toPath() },
       projectName = invocation.context.path.replace(":transformClassesWithLightsaberFor", ":").replace(':', '$'),
+      validateUsage = false,
       sharedBuildCache = LightsaberSharedBuildCache.create(),
     )
     logger.info("Starting Lightsaber processor: {}", parameters)

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransform.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransform.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 /*
  * Copyright 2022 SIA Joom
  *
@@ -25,6 +27,7 @@ import com.android.build.api.transform.TransformInvocation
 import com.android.build.api.transform.TransformOutputProvider
 import com.joom.lightsaber.processor.LightsaberParameters
 import com.joom.lightsaber.processor.LightsaberProcessor
+import com.joom.lightsaber.processor.LightsaberSharedBuildCache
 import com.joom.lightsaber.processor.logging.getLogger
 import java.io.File
 import java.io.IOException
@@ -65,7 +68,8 @@ class LightsaberTransform(
       },
       modulesClasspath = emptyList(),
       bootClasspath = extension.bootClasspath.map { it.toPath() },
-      projectName = invocation.context.path.replace(":transformClassesWithLightsaberFor", ":").replace(':', '$')
+      projectName = invocation.context.path.replace(":transformClassesWithLightsaberFor", ":").replace(':', '$'),
+      sharedBuildCache = LightsaberSharedBuildCache.create(),
     )
     logger.info("Starting Lightsaber processor: {}", parameters)
     val processor = LightsaberProcessor(parameters)

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
@@ -29,6 +29,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.CompileClasspath
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
@@ -59,6 +60,9 @@ abstract class LightsaberTransformTask : DefaultTask() {
   @Suppress("UnstableApiUsage")
   abstract val sharedBuildCacheService: Property<LightsaberSharedBuildCacheService>
 
+  @get:Input
+  abstract val validateUsage: Property<Boolean>
+
   private val projectName = formatProjectName()
 
   init {
@@ -76,6 +80,7 @@ abstract class LightsaberTransformTask : DefaultTask() {
       modulesClasspath = modulesClasspath.map { it.toPath() },
       gen = output,
       projectName = projectName,
+      validateUsage = validateUsage.get(),
       sharedBuildCache = sharedBuildCacheService.get().cache,
     )
 

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
@@ -76,6 +76,7 @@ abstract class LightsaberTransformTask : DefaultTask() {
       modulesClasspath = modulesClasspath.map { it.toPath() },
       gen = output,
       projectName = projectName,
+      sharedBuildCache = sharedBuildCacheService.get().cache,
     )
 
     logger.info("Starting Lightsaber processor: {}", parameters)

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
@@ -27,6 +27,7 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
@@ -39,15 +40,15 @@ abstract class LightsaberTransformTask : DefaultTask() {
   abstract val inputClasses: ListProperty<Directory>
 
   @get:InputFiles
-  @get:Classpath
+  @get:CompileClasspath
   abstract val bootClasspath: ConfigurableFileCollection
 
   @get:InputFiles
-  @get:Classpath
+  @get:CompileClasspath
   abstract val classpath: ConfigurableFileCollection
 
   @get:InputFiles
-  @get:Classpath
+  @get:CompileClasspath
   abstract val modulesClasspath: ConfigurableFileCollection
 
   @get:OutputDirectory

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
@@ -25,16 +25,17 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 abstract class LightsaberTransformTask : DefaultTask() {
-
   @get:InputFiles
   @get:Classpath
   abstract val inputClasses: ListProperty<Directory>
@@ -53,6 +54,10 @@ abstract class LightsaberTransformTask : DefaultTask() {
 
   @get:OutputDirectory
   abstract val outputDirectory: DirectoryProperty
+
+  @get:Internal
+  @Suppress("UnstableApiUsage")
+  abstract val sharedBuildCacheService: Property<LightsaberSharedBuildCacheService>
 
   private val projectName = formatProjectName()
 

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/CachedGripFactory.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/CachedGripFactory.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.processor
+
+import com.joom.grip.Grip
+import com.joom.grip.GripFactory
+import java.nio.file.Path
+
+internal object CachedGripFactory {
+  fun create(cache: LightsaberSharedBuildCache, paths: Iterable<Path>): Iterable<Grip> {
+    val visited = HashSet<Path>()
+
+    return paths
+      .asSequence()
+      .filter { visited.add(it) }
+      .map {
+        cache.getOrPut(GripKey(it)) { key ->
+          GripFactory.INSTANCE.create(key.path)
+        }
+      }
+      .asIterable()
+  }
+
+  private data class GripKey(val path: Path)
+}

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
@@ -92,17 +92,17 @@ class ClassProcessor(
   }
 
   private fun performAnalysisAndValidation(): InjectionContext {
-    val context = createAnalyzer().analyze(parameters.inputs, parameters.inputs + parameters.modulesClasspath)
+    val context = Analyzer(grip, errorReporter, parameters.projectName).analyze(parameters.inputs, parameters.inputs + parameters.modulesClasspath)
     val dependencyResolverFactory = DependencyResolverFactory(context)
     val hintsBuilder = HintsBuilder(grip.classRegistry)
     Validator(grip.classRegistry, errorReporter, context, dependencyResolverFactory, hintsBuilder).validate()
-    UsageValidator(grip, errorReporter, sourceResolver).validateUsage(context, parameters.modulesClasspath)
+
+    if (parameters.validateUsage) {
+      UsageValidator(grip, errorReporter, sourceResolver).validateUsage(context, parameters.modulesClasspath)
+    }
+
     checkErrors()
     return context
-  }
-
-  private fun createAnalyzer(): Analyzer {
-    return Analyzer(grip, errorReporter, parameters.projectName)
   }
 
   private fun copyAndPatchClasses(injectionContext: InjectionContext, generationContext: GenerationContext) {

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
@@ -85,6 +85,8 @@ class ClassProcessor(
       it.first.closeQuietly()
       it.second.closeQuietly()
     }
+
+    grip.closeQuietly()
   }
 
   private fun performAnalysisAndValidation(): InjectionContext {

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
@@ -98,7 +98,7 @@ class ClassProcessor(
     Validator(grip.classRegistry, errorReporter, context, dependencyResolverFactory, hintsBuilder).validate()
 
     if (parameters.validateUsage) {
-      UsageValidator(grip, errorReporter, sourceResolver).validateUsage(context, parameters.modulesClasspath)
+      UsageValidator(grip, errorReporter).validateUsage(parameters.modulesClasspath)
     }
 
     checkErrors()

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
@@ -92,7 +92,7 @@ class ClassProcessor(
   }
 
   private fun performAnalysisAndValidation(): InjectionContext {
-    val context = Analyzer(grip, errorReporter, parameters.projectName).analyze(parameters.inputs, parameters.inputs + parameters.modulesClasspath)
+    val context = Analyzer(grip, errorReporter, parameters.projectName).analyze(parameters.inputs)
     val dependencyResolverFactory = DependencyResolverFactory(context)
     val hintsBuilder = HintsBuilder(grip.classRegistry)
     Validator(grip.classRegistry, errorReporter, context, dependencyResolverFactory, hintsBuilder).validate()

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberParameters.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberParameters.kt
@@ -26,6 +26,7 @@ data class LightsaberParameters(
   val bootClasspath: List<Path>,
   val gen: Path,
   val projectName: String,
+  val validateUsage: Boolean,
+  val sharedBuildCache: LightsaberSharedBuildCache,
   val errorReporter: ErrorReporter = ErrorReporterImpl(),
-  val sharedBuildCache: LightsaberSharedBuildCache
 )

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberParameters.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberParameters.kt
@@ -26,5 +26,6 @@ data class LightsaberParameters(
   val bootClasspath: List<Path>,
   val gen: Path,
   val projectName: String,
-  val errorReporter: ErrorReporter = ErrorReporterImpl()
+  val errorReporter: ErrorReporter = ErrorReporterImpl(),
+  val sharedBuildCache: LightsaberSharedBuildCache
 )

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberSharedBuildCache.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberSharedBuildCache.kt
@@ -18,6 +18,6 @@ package com.joom.lightsaber.processor
 
 import java.io.Closeable
 
-interface LightsaberSharedBuildCache {
+interface LightsaberSharedBuildCache : Closeable {
   fun <K : Any, V : Closeable> getOrPut(key: K, factory: (key: K) -> V): V
 }

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberSharedBuildCache.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberSharedBuildCache.kt
@@ -16,8 +16,32 @@
 
 package com.joom.lightsaber.processor
 
+import com.joom.lightsaber.processor.commons.closeQuietly
 import java.io.Closeable
+import java.util.concurrent.ConcurrentHashMap
 
 interface LightsaberSharedBuildCache : Closeable {
   fun <K : Any, V : Closeable> getOrPut(key: K, factory: (key: K) -> V): V
+
+  companion object {
+    fun create(): LightsaberSharedBuildCache {
+      return LightsaberSharedBuildCacheImpl()
+    }
+  }
+}
+
+internal class LightsaberSharedBuildCacheImpl : LightsaberSharedBuildCache {
+  private val cache = ConcurrentHashMap<Any, Closeable>()
+
+  override fun <K : Any, V : Closeable> getOrPut(key: K, factory: (key: K) -> V): V {
+    @Suppress("UNCHECKED_CAST")
+    return (cache.getOrPut(key) { factory(key) } as V)
+  }
+
+  override fun close() {
+    cache.forEach {
+      it.value.closeQuietly()
+    }
+    cache.clear()
+  }
 }

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberSharedBuildCache.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberSharedBuildCache.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.processor
+
+import java.io.Closeable
+
+interface LightsaberSharedBuildCache {
+  fun <K : Any, V : Closeable> getOrPut(key: K, factory: (key: K) -> V): V
+}

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/analysis/FactoryParser.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/analysis/FactoryParser.kt
@@ -25,7 +25,6 @@ import com.joom.grip.methods
 import com.joom.grip.mirrors.ClassMirror
 import com.joom.grip.mirrors.MethodMirror
 import com.joom.grip.mirrors.Type
-import com.joom.grip.mirrors.getObjectTypeByInternalName
 import com.joom.grip.mirrors.signature.GenericType
 import com.joom.lightsaber.Factory.Return
 import com.joom.lightsaber.processor.ErrorReporter

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/analysis/FactoryParser.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/analysis/FactoryParser.kt
@@ -60,7 +60,7 @@ class FactoryParserImpl(
   }
 
   private fun parseFactory(mirror: ClassMirror): Factory {
-    val implementationType = getObjectTypeByInternalName("${mirror.type.internalName}\$Lightsaber\$Factory")
+    val implementationType = Factory.computeImplementationType(mirror.type)
     val qualifier = analyzerHelper.findQualifier(mirror)
     val dependency = Dependency(GenericType.Raw(mirror.type), qualifier)
     val provisionPoints = mirror.methods.mapNotNull { maybeCreateFactoryProvisionPoint(mirror, it) }

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/model/Factory.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/model/Factory.kt
@@ -17,10 +17,18 @@
 package com.joom.lightsaber.processor.model
 
 import com.joom.grip.mirrors.Type
+import com.joom.grip.mirrors.getObjectTypeByInternalName
 
 data class Factory(
   val type: Type.Object,
   val implementationType: Type.Object,
   val dependency: Dependency,
   val provisionPoints: List<FactoryProvisionPoint>
-)
+) {
+
+  companion object {
+    fun computeImplementationType(type: Type.Object): Type.Object {
+      return getObjectTypeByInternalName("${type.internalName}\$Lightsaber\$Factory")
+    }
+  }
+}

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/validation/UsageValidator.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/validation/UsageValidator.kt
@@ -28,27 +28,30 @@ import com.joom.grip.withField
 import com.joom.grip.withMethod
 import com.joom.lightsaber.LightsaberTypes
 import com.joom.lightsaber.processor.ErrorReporter
+import com.joom.lightsaber.processor.analysis.FactoryParser
 import com.joom.lightsaber.processor.analysis.SourceResolver
 import com.joom.lightsaber.processor.commons.Types
-import com.joom.lightsaber.processor.model.InjectionContext
+import com.joom.lightsaber.processor.model.Factory
 import java.nio.file.Path
 
 class UsageValidator(
   private val grip: Grip,
   private val errorReporter: ErrorReporter,
-  private val sourceResolver: SourceResolver,
 ) {
 
-  fun validateUsage(injectionContext: InjectionContext, paths: Collection<Path>) {
+  fun validateUsage(paths: Collection<Path>) {
     val modulesQuery = grip select classes from paths where annotatedWith(Types.MODULE_TYPE)
     val componentsQuery = grip select classes from paths where annotatedWith(Types.COMPONENT_TYPE)
     val contractConfigurationsQuery = grip select classes from paths where superType { _, type -> type == Types.CONTRACT_CONFIGURATION_TYPE }
     val fieldsQuery = grip select classes from paths where withField { _, fieldMirror -> fieldMirror.annotations.contains(Types.INJECT_TYPE) }
     val methodsQuery = grip select classes from paths where withMethod { _, methodMirror -> methodMirror.annotations.contains(Types.INJECT_TYPE) }
+    val factoriesQuery = grip select classes from paths where annotatedWith(Types.FACTORY_TYPE)
 
-    injectionContext.factories.forEach { factory ->
-      if (!sourceResolver.belongsToCurrentInput(factory.type) && !grip.fileRegistry.contains(factory.implementationType)) {
-        reportError(factory.type)
+    execute(factoriesQuery).forEach { (type, _) ->
+      val implementationType = Factory.computeImplementationType(type)
+
+      if (!grip.fileRegistry.contains(implementationType)) {
+        reportError(type)
       }
     }
 

--- a/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/LightsaberSharedBuildCacheImplTest.kt
+++ b/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/LightsaberSharedBuildCacheImplTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.processor
+
+import org.junit.Assert
+import org.junit.Test
+import java.io.Closeable
+
+class LightsaberSharedBuildCacheImplTest {
+
+  @Test
+  fun `getOrPut - calls factory - no key in cache`() {
+    val cache = LightsaberSharedBuildCache.create()
+
+    var called = false
+    cache.getOrPut("Key") {
+      called = true
+      TestCloseable()
+    }
+
+    Assert.assertTrue("Factory was not called", called)
+  }
+
+  @Test
+  fun `getOrPut - returns same instance - key present in cache`() {
+    val cache = LightsaberSharedBuildCache.create()
+    val expected = TestCloseable()
+
+    cache.getOrPut("Key") {
+      expected
+    }
+
+    val actual = cache.getOrPut("Key") { TestCloseable() }
+
+    Assert.assertSame("Instances were not the same", expected, actual)
+  }
+
+  @Test
+  fun `close - closes Closeable`() {
+    val cache = LightsaberSharedBuildCache.create()
+    val closeable = TestCloseable()
+    cache.getOrPut("Key") {
+      closeable
+    }
+
+    cache.close()
+
+    Assert.assertTrue("Closeable was not closed", closeable.closed)
+  }
+
+  @Test
+  fun `close - clears cache`() {
+    val cache = LightsaberSharedBuildCache.create()
+    val firstCloseable = TestCloseable()
+    val secondCloseable = TestCloseable()
+    cache.getOrPut("Key") { firstCloseable }
+
+    cache.close()
+
+    val actual = cache.getOrPut("Key") { secondCloseable }
+    Assert.assertSame("Cache was not closed", secondCloseable, actual)
+  }
+
+  private class TestCloseable : Closeable {
+    var closed: Boolean = false
+      private set
+
+    override fun close() {
+      closed = true
+    }
+  }
+}

--- a/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/integration/IntegrationTestRule.kt
+++ b/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/integration/IntegrationTestRule.kt
@@ -20,6 +20,7 @@ import com.joom.lightsaber.processor.ErrorReporter
 import com.joom.lightsaber.processor.JvmRuntimeUtil
 import com.joom.lightsaber.processor.LightsaberParameters
 import com.joom.lightsaber.processor.LightsaberProcessor
+import com.joom.lightsaber.processor.LightsaberSharedBuildCache
 import com.joom.lightsaber.processor.ProcessingException
 import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
@@ -100,7 +101,8 @@ class IntegrationTestRule(
       classpath = emptyList(),
       projectName = projectName,
       gen = outputDirectory,
-      errorReporter = errorReporter
+      errorReporter = errorReporter,
+      sharedBuildCache = LightsaberSharedBuildCache.create(),
     )
 
     try {

--- a/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/integration/IntegrationTestRule.kt
+++ b/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/integration/IntegrationTestRule.kt
@@ -91,6 +91,7 @@ class IntegrationTestRule(
     errorReporter: ErrorReporter,
     modules: List<Path> = emptyList(),
     ignoreErrors: Boolean = false,
+    validateUsage: Boolean = true,
   ): Path {
     val outputDirectory = processedDirectory.resolve(projectName)
     val parameters = LightsaberParameters(
@@ -102,6 +103,7 @@ class IntegrationTestRule(
       projectName = projectName,
       gen = outputDirectory,
       errorReporter = errorReporter,
+      validateUsage = validateUsage,
       sharedBuildCache = LightsaberSharedBuildCache.create(),
     )
 

--- a/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/validation/UsageValidatorTest.kt
+++ b/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/validation/UsageValidatorTest.kt
@@ -28,13 +28,14 @@ class UsageValidatorTest {
   private val reporter = TestErrorReporter()
 
   @Test
-  fun test_check_failed_not_processed_classes_on_modules_classpath() {
+  fun test_check_failed_not_processed_classes_on_modules_classpath_validate_usage_enabled() {
     val dependencyProjectCompiled = integrationTestRule.compileProject("dependency_project")
     val referencingProjectCompiled = integrationTestRule.compileProject("referencing_dependency_project", classpath = listOf(dependencyProjectCompiled))
 
     integrationTestRule.processProject(
       referencingProjectCompiled, "referencing_dependency_project", reporter, listOf(dependencyProjectCompiled),
-      ignoreErrors = true
+      ignoreErrors = true,
+      validateUsage = true,
     )
 
     reporter.assertErrorReported(
@@ -53,6 +54,19 @@ class UsageValidatorTest {
       "Class test_case_projects.usage_validator.dependency_project.DependencyProjectFactory is not processed by lightsaber," +
           " is plugin applied to module?"
     )
+  }
+
+  @Test
+  fun test_check_successful_not_processed_classes_on_modules_classpath_validate_usage_disabled() {
+    val dependencyProjectCompiled = integrationTestRule.compileProject("dependency_project")
+    val referencingProjectCompiled = integrationTestRule.compileProject("referencing_dependency_project", classpath = listOf(dependencyProjectCompiled))
+
+    integrationTestRule.processProject(
+      referencingProjectCompiled, "referencing_dependency_project", reporter, listOf(dependencyProjectCompiled),
+      validateUsage = false,
+    )
+
+    reporter.assertNoErrorsReported()
   }
 
   @Test


### PR DESCRIPTION
This PR introduces several performance and memory optimizations:
* Introduced `LightsaberSharedBuildCache` that caches classpath `Grip` instances. The cache is shared between Lightsaber tasks with Gradle Build Service. Unfortunately, due to [Gradle issue](https://github.com/gradle/gradle/issues/17559), the plugin has to register Build Service for every classloader. Build Service preemptively clears cache when all tasks that were registered for it have finished their execution.
* `ClassProcessor` closes `Grip` instance when closing itself.
* Introduced `validateUsage` Lightsaber extension flag (enabled by default) which controls whether Lightsaber will scan current Gradle module classpath for incorrect usage. This flag can improve memory usage for multimodule Gradle projects. One can disable this flag for "library" modules and enable it only for the final "application" module.
* `Analyzer` no longer uses `modulesClasspath` to create `InjectionContext`, instead it analyzes `Path` of particular `Module` lazily when needed.