### PR TITLE
Basic bounded generics support

### DIFF
--- a/lightsaber/core/src/main/java/com/joom/lightsaber/internal/WildcardTypeImpl.java
+++ b/lightsaber/core/src/main/java/com/joom/lightsaber/internal/WildcardTypeImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.internal;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.Arrays;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class WildcardTypeImpl implements WildcardType {
+  @Nonnull
+  private final Type[] upperBounds;
+  @Nonnull
+  private final Type[] lowerBounds;
+
+  public WildcardTypeImpl(
+    @Nullable final Type upperBound,
+    @Nullable final Type lowerBound
+  ) {
+    this.upperBounds = upperBound != null ? new Type[]{upperBound} : new Type[0];
+    this.lowerBounds = lowerBound != null ? new Type[]{lowerBound} : new Type[0];
+  }
+
+  @Override
+  public Type[] getUpperBounds() {
+    return upperBounds;
+  }
+
+  @Override
+  public Type[] getLowerBounds() {
+    return lowerBounds;
+  }
+
+  @Override
+  public String getTypeName() {
+    if (lowerBounds.length != 0) {
+      return "? super " + lowerBounds[0].getTypeName();
+    }
+
+    if (upperBounds.length != 0 && !upperBounds[0].equals(Object.class)) {
+      return "? extends" + upperBounds[0].getTypeName();
+    }
+
+    return "?";
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof WildcardType)) {
+      return false;
+    }
+
+    if (!Arrays.equals(lowerBounds, ((WildcardType) other).getLowerBounds())) {
+      return false;
+    }
+
+    return Arrays.equals(upperBounds, ((WildcardType) other).getUpperBounds());
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(upperBounds) ^ Arrays.hashCode(lowerBounds);
+  }
+}

--- a/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/generation/GeneratorTest.kt
+++ b/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/generation/GeneratorTest.kt
@@ -102,6 +102,11 @@ class GeneratorTest {
     integrationTestRule.assertValidProject("parameterized_type")
   }
 
+  @Test
+  fun `generates provider for bounded generics`() {
+    integrationTestRule.assertValidProject("bounded_generics")
+  }
+
   private fun Path.shouldContain(path: Path) {
     Assert.assertTrue(resolve(path).exists())
   }

--- a/lightsaber/processor/src/test/resources/test_case_projects/generator/bounded_generics/Configuration.kt
+++ b/lightsaber/processor/src/test/resources/test_case_projects/generator/bounded_generics/Configuration.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_case_projects.generator.bounded_generics
+
+import com.joom.lightsaber.ContractConfiguration
+import com.joom.lightsaber.Provide
+
+interface Key
+
+interface Value<T : Any> {
+  val value: T
+}
+
+interface GenericContainerValue<K : Any, V : Any>
+
+interface GenericContract {
+  val value: GenericContainerValue<Key, Value<*>>
+}
+
+class GenericContractConfiguration : ContractConfiguration<GenericContract>() {
+
+  @Provide
+  fun provideValue(): GenericContainerValue<Key, Value<*>> {
+    return object : GenericContainerValue<Key, Value<*>> {}
+  }
+}

--- a/samples/injection-test/src/test/java/com/joom/lightsaber/BoundedGenericTest.kt
+++ b/samples/injection-test/src/test/java/com/joom/lightsaber/BoundedGenericTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber
+
+import org.junit.Assert
+import org.junit.Test
+
+class BoundedGenericTest {
+  @Test
+  fun test() {
+    val contract = Lightsaber.Builder().build().createContract(BoundedGenericContractConfiguration())
+
+    Assert.assertEquals(FirstTestKey("Key"), contract.firstContainer.key)
+    Assert.assertEquals(FirstTestValue("Value"), contract.firstContainer.value)
+
+    Assert.assertEquals(SecondTestKey("Key"), contract.secondContainer.key)
+    Assert.assertEquals(SecondTestValue("Value"), contract.secondContainer.value)
+  }
+
+  private interface BoundedGenericContainer<K : Key<*>, V : Value<*>> {
+    val key: K
+    val value: V
+  }
+
+  private interface Key<T : Any>
+
+  private interface Value<T : Any>
+
+  private data class FirstTestKey<T : Any>(val key: T) : Key<T>
+
+  private data class FirstTestValue<T : Any>(val value: T) : Value<T>
+
+  private data class SecondTestKey<T : Any>(val key: T) : Key<T>
+
+  private data class SecondTestValue<T : Any>(val value: T) : Value<T>
+
+  private interface BoundedGenericContract {
+    val firstContainer: BoundedGenericContainer<FirstTestKey<*>, FirstTestValue<*>>
+    val secondContainer: BoundedGenericContainer<SecondTestKey<*>, SecondTestValue<*>>
+  }
+
+  private class BoundedGenericContractConfiguration : ContractConfiguration<BoundedGenericContract>() {
+    @Provide
+    fun provideFirstTestContainer(): BoundedGenericContainer<FirstTestKey<*>, FirstTestValue<*>> {
+      return BoundedGenericContainerImpl(FirstTestKey("Key"), FirstTestValue("Value"))
+    }
+
+    @Provide
+    fun provideSecondTestContainer(): BoundedGenericContainer<SecondTestKey<*>, SecondTestValue<*>> {
+      return BoundedGenericContainerImpl(SecondTestKey("Key"), SecondTestValue("Value"))
+    }
+
+    private class BoundedGenericContainerImpl<K : Key<*>, V : Value<*>>(
+      override val key: K,
+      override val value: V
+    ) : BoundedGenericContainer<K, V>
+  }
+}


### PR DESCRIPTION
This PR introduces bounded generics support in `KeyRegistryClassGenerator`. Proposed solution, probably naive, but it fixes some cases with wildcard generics.