### PR TITLE
ClassProcessor appends logged errors to ProcessingException

### DIFF
--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
@@ -148,7 +148,7 @@ class ClassProcessor(
 
   private fun checkErrors() {
     if (errorReporter.hasErrors) {
-      throw ProcessingException("Errors found")
+      throw ProcessingException(errorReporter.errors.joinToString(prefix = "Errors found:\n", separator = "\n"))
     }
   }
 

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ErrorReporter.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ErrorReporter.kt
@@ -16,21 +16,27 @@
 
 package com.joom.lightsaber.processor
 
+import com.joom.lightsaber.processor.commons.immutable
 import com.joom.lightsaber.processor.logging.getLogger
 
 interface ErrorReporter {
   val hasErrors: Boolean
+  val errors: List<String>
   fun reportError(errorMessage: String, exception: Throwable? = null)
 }
 
 class ErrorReporterImpl : ErrorReporter {
   private val logger = getLogger()
+  private val loggedErrors = ArrayList<String>()
 
-  override var hasErrors: Boolean = false
-    private set
+  override val hasErrors: Boolean
+    get() = loggedErrors.isNotEmpty()
+
+  override val errors: List<String>
+    get() = loggedErrors.immutable()
 
   override fun reportError(errorMessage: String, exception: Throwable?) {
-    hasErrors = true
+    loggedErrors += errorMessage
     logger.error(errorMessage, exception)
   }
 }

--- a/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/integration/TestErrorReporter.kt
+++ b/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/integration/TestErrorReporter.kt
@@ -17,20 +17,12 @@
 package com.joom.lightsaber.processor.integration
 
 import com.joom.lightsaber.processor.ErrorReporter
+import com.joom.lightsaber.processor.ErrorReporterImpl
 import org.junit.Assert
 
-class TestErrorReporter : ErrorReporter {
-  private val errors = ArrayList<LoggedError>()
-
-  override fun reportError(errorMessage: String, exception: Throwable?) {
-    errors += LoggedError(errorMessage, exception)
-  }
-
-  override val hasErrors: Boolean
-    get() = errors.isNotEmpty()
-
+class TestErrorReporter(private val delegate: ErrorReporter = ErrorReporterImpl()) : ErrorReporter by delegate {
   fun assertErrorReported(message: String) {
-    Assert.assertTrue("Expected '${message}', got:\n${errorsToString()}", errors.any { it.message == message })
+    Assert.assertTrue("Expected '${message}', got:\n${errorsToString()}", errors.any { it == message })
   }
 
   fun assertNoErrorsReported() {
@@ -38,11 +30,6 @@ class TestErrorReporter : ErrorReporter {
   }
 
   private fun errorsToString(): String {
-    return errors.joinToString("\n") { it.message }
+    return errors.joinToString("\n") { it }
   }
-
-  private data class LoggedError(
-    val message: String,
-    val throwable: Throwable?
-  )
 }


### PR DESCRIPTION
Logged error messages are hard to find in Gradle build log, especially in multi project build. This PR adds all logged messages to `ProcessingException` which is thrown by Lightsaber at the end of the processing.