### PR TITLE
LightsaberTransformTask should clear output directory

### DIFF
--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
@@ -71,6 +71,8 @@ abstract class LightsaberTransformTask : DefaultTask() {
 
   @TaskAction
   fun process() {
+    clean()
+
     val output = outputDirectory.get().asFile.toPath()
     val parameters = LightsaberParameters(
       inputs = inputClasses.get().map { it.asFile.toPath() },
@@ -91,6 +93,14 @@ abstract class LightsaberTransformTask : DefaultTask() {
       processor.process()
     } catch (exception: Exception) {
       throw GradleScriptException("Lightsaber processor failed to process files", exception)
+    }
+  }
+
+  private fun clean() {
+    val output = outputDirectory.get().asFile
+
+    if (output.exists()) {
+      output.deleteRecursively()
     }
   }
 


### PR DESCRIPTION
Gradle does not clean `outputDirectory` automatically, although `LightsaberTransformTask` is not incremental. This PR fixes the issue when previously deleted classes can still be available in the resulting APK.