### PR TITLE
add support for auto instantiation of contract imports with eager dependencies

### DIFF
--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/commons/Methods.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/commons/Methods.kt
@@ -23,4 +23,7 @@ object Methods {
   val HASH_CODE_METHOD = MethodDescriptor.forMethod("hashCode", Type.Primitive.Int)
   val EQUALS_METHOD = MethodDescriptor.forMethod("equals", Type.Primitive.Boolean, Types.OBJECT_TYPE)
   val TO_STRING_METHOD = MethodDescriptor.forMethod("toString", Types.STRING_TYPE)
+
+  val GET_VALUE_METHOD = MethodDescriptor.forMethod("getValue", Types.OBJECT_TYPE)
+  val GET_METHOD = MethodDescriptor.forMethod("get", Types.OBJECT_TYPE)
 }

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/generation/ProviderClassGenerator.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/generation/ProviderClassGenerator.kt
@@ -22,6 +22,8 @@ import com.joom.grip.mirrors.getObjectType
 import com.joom.grip.mirrors.isPrimitive
 import com.joom.lightsaber.LightsaberTypes
 import com.joom.lightsaber.processor.commons.GeneratorAdapter
+import com.joom.lightsaber.processor.commons.Methods.GET_METHOD
+import com.joom.lightsaber.processor.commons.Methods.GET_VALUE_METHOD
 import com.joom.lightsaber.processor.commons.StandaloneClassWriter
 import com.joom.lightsaber.processor.commons.Types
 import com.joom.lightsaber.processor.commons.exhaustive
@@ -316,10 +318,6 @@ class ProviderClassGenerator(
 
     private val CONSTRUCTOR_WITH_INJECTOR = MethodDescriptor.forConstructor(Types.INJECTOR_TYPE)
 
-    private val GET_VALUE_METHOD =
-      MethodDescriptor.forMethod("getValue", Types.OBJECT_TYPE)
-    private val GET_METHOD =
-      MethodDescriptor.forMethod("get", Types.OBJECT_TYPE)
     private val INJECT_MEMBERS_METHOD =
       MethodDescriptor.forMethod("injectMembers", Type.Primitive.Void, Types.OBJECT_TYPE)
   }

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/injection/ModulePatcher.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/injection/ModulePatcher.kt
@@ -263,7 +263,7 @@ class ModulePatcher(
   private fun GeneratorAdapter.configureInjectorWithContract(import: Import.Contract) {
     val maybeLazy = when (import.importPoint.converter) {
       is ImportPoint.Converter.Adapter -> true
-      ImportPoint.Converter.Instance -> false
+      is ImportPoint.Converter.Instance -> false
     }
 
     if (maybeLazy && shouldInstantiateImmediately(import.contract)) {

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/injection/ModulePatcher.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/injection/ModulePatcher.kt
@@ -285,12 +285,12 @@ class ModulePatcher(
   private fun shouldInstantiateImmediately(contract: Contract): Boolean {
     val dependencies = contract.provisionPoints.map { it.injectee.dependency }.toHashSet()
 
-    val configuration = injectionContext.contractConfigurations.firstOrNull { it.contract == contract } ?: return false
-
-    for (module in configuration.defaultModule.getModulesWithDescendants()) {
-      for (provisionPoint in module.provisionPoints) {
-        if (provisionPoint.scope.isEager && dependencies.contains(provisionPoint.dependency)) {
-          return true
+    for (configuration in injectionContext.contractConfigurations.filter { it.contract == contract }) {
+      for (module in configuration.getModulesWithDescendants()) {
+        for (provisionPoint in module.provisionPoints) {
+          if (provisionPoint.scope.isEager && dependencies.contains(provisionPoint.dependency)) {
+            return true
+          }
         }
       }
     }

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/injection/ModulePatcher.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/injection/ModulePatcher.kt
@@ -22,6 +22,8 @@ import com.joom.grip.mirrors.Type
 import com.joom.grip.mirrors.isStatic
 import com.joom.lightsaber.LightsaberTypes
 import com.joom.lightsaber.processor.commons.GeneratorAdapter
+import com.joom.lightsaber.processor.commons.Methods.GET_METHOD
+import com.joom.lightsaber.processor.commons.Methods.GET_VALUE_METHOD
 import com.joom.lightsaber.processor.commons.Types
 import com.joom.lightsaber.processor.commons.exhaustive
 import com.joom.lightsaber.processor.commons.invokeMethod
@@ -177,7 +179,6 @@ class ModulePatcher(
     loadModule(import.importPoint)
     loadArg(0)
 
-
     val constructor = when (val converter = import.importPoint.converter) {
       is ImportPoint.Converter.Adapter -> MethodDescriptor.forConstructor(converter.adapterType, Types.INJECTOR_TYPE)
       is ImportPoint.Converter.Instance -> MethodDescriptor.forConstructor(import.contract.type, Types.INJECTOR_TYPE)
@@ -298,12 +299,6 @@ class ModulePatcher(
   }
 
   companion object {
-    private val GET_VALUE_METHOD =
-      MethodDescriptor.forMethod("getValue", Types.OBJECT_TYPE)
-
-    private val GET_METHOD =
-      MethodDescriptor.forMethod("get", Types.OBJECT_TYPE)
-
     private val CONFIGURE_INJECTOR_METHOD =
       MethodDescriptor.forMethod("configureInjector", Type.Primitive.Void, LightsaberTypes.LIGHTSABER_INJECTOR_TYPE)
   }

--- a/samples/injection-test/src/test/java/com/joom/lightsaber/LazyContractImportTest.kt
+++ b/samples/injection-test/src/test/java/com/joom/lightsaber/LazyContractImportTest.kt
@@ -312,6 +312,29 @@ class LazyContractImportTest {
     assertEquals(1, nestedEagerContractConfiguration.counter.get())
   }
 
+  @Test
+  fun testEagerContractWithNonEagerConfiguration() {
+    val lightsaber = Lightsaber.Builder().build()
+    var contractWithoutEagerInstantiated = false
+    val configuration = EagerDependencyContractConfiguration(
+      lazy {
+        contractWithoutEagerInstantiated = true
+        lightsaber.createContract(NestedNonEagerContractConfiguration())
+      },
+      lazy {
+        object : DummyContract {
+          override val int: Int
+            get() = 1
+        }
+      }
+    )
+
+    val contract = lightsaber.createContract(configuration)
+
+    assertEquals(true, contractWithoutEagerInstantiated)
+  }
+
+
   @Component
   class ContractComponent(
     @Import
@@ -641,6 +664,14 @@ class LazyContractImportTest {
 
     @Provide
     @Eager
+    @Singleton
+    fun provideString(): String = counter.getAndIncrement().toString()
+  }
+
+  class NestedNonEagerContractConfiguration : ContractConfiguration<NestedEagerContract>() {
+    val counter = AtomicInteger()
+
+    @Provide
     @Singleton
     fun provideString(): String = counter.getAndIncrement().toString()
   }

--- a/samples/injection-test/src/test/java/com/joom/lightsaber/LazyContractImportTest.kt
+++ b/samples/injection-test/src/test/java/com/joom/lightsaber/LazyContractImportTest.kt
@@ -290,9 +290,9 @@ class LazyContractImportTest {
     assertEquals(1, nestedEagerContractConfiguration.counter.get())
     assertEquals("0", contract.string)
     assertEquals(1, nestedEagerContractConfiguration.counter.get())
-    assertEquals(contractWithoutEagerInstantiated, false)
+    assertEquals(false, contractWithoutEagerInstantiated)
     assertEquals(1, contract.int)
-    assertEquals(contractWithoutEagerInstantiated, true)
+    assertEquals(true, contractWithoutEagerInstantiated)
   }
 
   @Test


### PR DESCRIPTION
in #8 deferred instantiation of imported contracts was supported. But there was a case with eager dependencies - they wouldn't have been instantiated before the contract was created. So, in this PR I added support for contracts auto instantiation, if they provide any eager dependencies.