### PR TITLE
Plugin flag to dump debug information to a file

### DIFF
--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AndroidLightsaberPlugin.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AndroidLightsaberPlugin.kt
@@ -30,6 +30,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.provider.Provider
 import java.io.File
+import java.nio.file.Paths
 
 abstract class AndroidLightsaberPlugin : BaseLightsaberPlugin() {
   override fun apply(project: Project) {
@@ -173,7 +174,7 @@ abstract class AndroidLightsaberPlugin : BaseLightsaberPlugin() {
   }
 
   private fun computeReportDirectory(): File {
-    return File(project.buildDir, "reports/lightsaber")
+    return Paths.get(project.buildDir.path, "reports", "lightsaber").toFile()
   }
 
   private companion object {

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AndroidLightsaberPlugin.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AndroidLightsaberPlugin.kt
@@ -29,6 +29,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.provider.Provider
+import java.io.File
 
 abstract class AndroidLightsaberPlugin : BaseLightsaberPlugin() {
   override fun apply(project: Project) {
@@ -54,30 +55,44 @@ abstract class AndroidLightsaberPlugin : BaseLightsaberPlugin() {
     }
   }
 
-  private fun configureTransformWithComponents(extension: AndroidLightsaberPluginExtension, buildCacheService: Provider<LightsaberSharedBuildCacheService>) {
+  private fun configureTransformWithComponents(
+    extension: AndroidLightsaberPluginExtension,
+    buildCacheService: Provider<LightsaberSharedBuildCacheService>
+  ) {
     val validateUsage = project.provider { extension.validateUsage }
+    val dumpDebugReport = project.provider { extension.dumpDebugReport }
 
     project.applicationAndroidComponents?.apply {
       onVariants { variant ->
-        variant.registerLightsaberTask(validateUsage, buildCacheService)
+        variant.registerLightsaberTask(
+          validateUsage = validateUsage,
+          dumpDebugReport = dumpDebugReport,
+          buildCacheService = buildCacheService
+        )
       }
     }
 
     project.libraryAndroidComponents?.apply {
       onVariants { variant ->
-        variant.registerLightsaberTask(validateUsage, buildCacheService)
+        variant.registerLightsaberTask(
+          validateUsage = validateUsage,
+          dumpDebugReport = dumpDebugReport,
+          buildCacheService = buildCacheService
+        )
       }
     }
   }
 
   private fun <T> T.registerLightsaberTask(
     validateUsage: Provider<Boolean>,
+    dumpDebugReport: Provider<Boolean>,
     buildCacheService: Provider<LightsaberSharedBuildCacheService>
   ) where T : Variant, T : HasAndroidTest {
     val runtimeClasspath = runtimeClasspathConfiguration()
 
     registerLightsaberTask(
       validateUsage = validateUsage,
+      dumpDebugReport = dumpDebugReport,
       classpathProvider = classpathProvider(runtimeClasspath),
       modulesClasspathProvider = modulesClasspathProvider(runtimeClasspath),
       buildCacheService = buildCacheService,
@@ -88,6 +103,7 @@ abstract class AndroidLightsaberPlugin : BaseLightsaberPlugin() {
 
       androidTest.registerLightsaberTask(
         validateUsage = validateUsage,
+        dumpDebugReport = dumpDebugReport,
         classpathProvider = classpathProvider(androidTestRuntimeClasspath),
         modulesClasspathProvider = modulesClasspathProvider(androidTestRuntimeClasspath) - modulesClasspathProvider(runtimeClasspath),
         buildCacheService = buildCacheService,
@@ -97,6 +113,7 @@ abstract class AndroidLightsaberPlugin : BaseLightsaberPlugin() {
 
   private fun Component.registerLightsaberTask(
     validateUsage: Provider<Boolean>,
+    dumpDebugReport: Provider<Boolean>,
     classpathProvider: Provider<FileCollection>,
     modulesClasspathProvider: Provider<FileCollection>,
     buildCacheService: Provider<LightsaberSharedBuildCacheService>,
@@ -118,6 +135,7 @@ abstract class AndroidLightsaberPlugin : BaseLightsaberPlugin() {
       task.bootClasspath.from(project.androidComponents!!.sdkComponents.bootClasspath)
       task.sharedBuildCacheService.set(buildCacheService)
       task.validateUsage.set(validateUsage)
+      task.dumpDebugReport.set(dumpDebugReport)
 
       @Suppress("UnstableApiUsage")
       task.usesService(buildCacheService)
@@ -145,12 +163,17 @@ abstract class AndroidLightsaberPlugin : BaseLightsaberPlugin() {
       return
     }
 
-    val transform = LightsaberTransform(extension)
+    val reportDirectory = computeReportDirectory()
+    val transform = LightsaberTransform(extension, reportDirectory.toPath())
     project.android.registerTransform(transform)
 
     project.afterEvaluate {
       extension.bootClasspath = project.android.bootClasspath
     }
+  }
+
+  private fun computeReportDirectory(): File {
+    return File(project.buildDir, "reports/lightsaber")
   }
 
   private companion object {

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AndroidLightsaberPluginExtension.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AndroidLightsaberPluginExtension.kt
@@ -4,6 +4,7 @@ import java.io.File
 
 open class AndroidLightsaberPluginExtension {
   var validateUsage: Boolean = true
+  var dumpDebugReport: Boolean = false
   var cacheable: Boolean = false
   var bootClasspath: List<File> = emptyList()
 }

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/JavaLightsaberPluginExtension.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/JavaLightsaberPluginExtension.kt
@@ -19,4 +19,5 @@ package com.joom.lightsaber.plugin
 open class JavaLightsaberPluginExtension {
   var processTest: Boolean = true
   var validateUsage: Boolean = true
+  var dumpDebugReport: Boolean = false
 }

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
@@ -23,6 +23,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleScriptException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
@@ -33,10 +34,14 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 import java.net.URI
 import java.nio.file.FileSystems
+import javax.inject.Inject
 
-abstract class LightsaberTask : DefaultTask() {
+abstract class LightsaberTask @Inject constructor(
+  private val projectLayout: ProjectLayout
+) : DefaultTask() {
   @get:InputFiles
   @get:Classpath
   abstract val backupDirs: ConfigurableFileCollection
@@ -66,6 +71,9 @@ abstract class LightsaberTask : DefaultTask() {
   @get:Input
   abstract val validateUsage: Property<Boolean>
 
+  @get:Input
+  abstract val dumpDebugReport: Property<Boolean>
+
   private val projectName = formatProjectName()
 
   init {
@@ -88,6 +96,8 @@ abstract class LightsaberTask : DefaultTask() {
       projectName = projectName,
       sharedBuildCache = sharedBuildCacheService.get().cache,
       validateUsage = validateUsage.get(),
+      dumpDebugReport = dumpDebugReport.get(),
+      reportDirectory = computeReportDirectory().toPath()
     )
 
     logger.info("Starting Lightsaber processor: {}", parameters)
@@ -127,6 +137,8 @@ abstract class LightsaberTask : DefaultTask() {
       logger.info("Removing a directory with generated source files: {}", sourceDir)
       sourceDir.get().asFile.deleteRecursively()
     }
+
+    computeReportDirectory().deleteRecursively()
   }
 
   private fun validate() {
@@ -134,6 +146,10 @@ abstract class LightsaberTask : DefaultTask() {
     require(!backupDirs.isEmpty) { "backupDirs is not set" }
     require(classesDirs.files.size == backupDirs.files.size) { "classesDirs and backupDirs must have equal size" }
     require(sourceDir.isPresent) { "sourceDir is not set" }
+  }
+
+  private fun computeReportDirectory(): File {
+    return File(projectLayout.buildDirectory.get().asFile, "reports/lightsaber")
   }
 
   companion object {

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTask.kt
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.net.URI
 import java.nio.file.FileSystems
+import java.nio.file.Paths
 import javax.inject.Inject
 
 abstract class LightsaberTask @Inject constructor(
@@ -149,7 +150,7 @@ abstract class LightsaberTask @Inject constructor(
   }
 
   private fun computeReportDirectory(): File {
-    return File(projectLayout.buildDirectory.get().asFile, "reports/lightsaber")
+    return Paths.get(projectLayout.buildDirectory.get().asFile.path, "reports", "lightsaber").toFile()
   }
 
   companion object {

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransform.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransform.kt
@@ -31,10 +31,12 @@ import com.joom.lightsaber.processor.LightsaberSharedBuildCache
 import com.joom.lightsaber.processor.logging.getLogger
 import java.io.File
 import java.io.IOException
+import java.nio.file.Path
 import java.util.EnumSet
 
 class LightsaberTransform(
-  private val extension: AndroidLightsaberPluginExtension
+  private val extension: AndroidLightsaberPluginExtension,
+  private val reportDirectory: Path
 ) : Transform() {
   private val logger = getLogger()
 
@@ -69,7 +71,9 @@ class LightsaberTransform(
       modulesClasspath = emptyList(),
       bootClasspath = extension.bootClasspath.map { it.toPath() },
       projectName = invocation.context.path.replace(":transformClassesWithLightsaberFor", ":").replace(':', '$'),
-      validateUsage = false,
+      validateUsage = extension.validateUsage,
+      dumpDebugReport = extension.dumpDebugReport,
+      reportDirectory = reportDirectory,
       sharedBuildCache = LightsaberSharedBuildCache.create(),
     )
     logger.info("Starting Lightsaber processor: {}", parameters)
@@ -96,6 +100,8 @@ class LightsaberTransform(
 
   override fun getParameterInputs(): MutableMap<String, Any> {
     return mutableMapOf(
+      "validateUsage" to extension.validateUsage,
+      "dumpDebugReport" to extension.dumpDebugReport,
       "cacheable" to extension.cacheable,
       "bootClasspath" to extension.bootClasspath
         .map { it.absolutePath }

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
@@ -36,6 +36,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.io.File
+import java.nio.file.Paths
 import javax.inject.Inject
 
 @CacheableTask
@@ -126,7 +127,7 @@ abstract class LightsaberTransformTask @Inject constructor(
   }
 
   private fun computeReportDirectory(): File {
-    return File(projectLayout.buildDirectory.get().asFile, "reports/lightsaber")
+    return Paths.get(projectLayout.buildDirectory.get().asFile.path, "reports", "lightsaber").toFile()
   }
 
   companion object {

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
@@ -97,12 +97,7 @@ class ClassProcessor(
     val hintsBuilder = HintsBuilder(grip.classRegistry)
 
     if (parameters.dumpDebugReport) {
-      val report = File(parameters.reportDirectory.toFile(), "debug-dump.txt")
-
-      report.parentFile.mkdirs()
-      report.createNewFile()
-
-      FileDumpContext(report).use { dumpContext ->
+      FileDumpContext(getOrCreateReportFile()).use { dumpContext ->
         DebugReport.dump(context, dumpContext)
       }
     }
@@ -162,6 +157,16 @@ class ClassProcessor(
       .forEach {
         grip.classRegistry.getClassMirror(it)
       }
+  }
+
+  private fun getOrCreateReportFile(): File {
+    val report = File(parameters.reportDirectory.toFile(), "debug-dump.txt")
+    report.parentFile.mkdirs()
+    report.createNewFile()
+    if (!report.exists()) {
+      error("Unable to create a report file $report")
+    }
+    return report
   }
 
   private fun checkErrors() {

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/ClassProcessor.kt
@@ -32,15 +32,7 @@ import com.joom.lightsaber.processor.generation.model.GenerationContext
 import com.joom.lightsaber.processor.generation.model.ProviderFactoryImpl
 import com.joom.lightsaber.processor.injection.Patcher
 import com.joom.lightsaber.processor.logging.getLogger
-import com.joom.lightsaber.processor.model.Component
-import com.joom.lightsaber.processor.model.Contract
-import com.joom.lightsaber.processor.model.ContractConfiguration
-import com.joom.lightsaber.processor.model.Import
 import com.joom.lightsaber.processor.model.InjectionContext
-import com.joom.lightsaber.processor.model.InjectionPoint
-import com.joom.lightsaber.processor.model.InjectionTarget
-import com.joom.lightsaber.processor.model.Module
-import com.joom.lightsaber.processor.model.ProvisionPoint
 import com.joom.lightsaber.processor.validation.DependencyResolverFactory
 import com.joom.lightsaber.processor.validation.HintsBuilder
 import com.joom.lightsaber.processor.validation.UsageValidator
@@ -48,6 +40,7 @@ import com.joom.lightsaber.processor.validation.Validator
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassWriter
 import java.io.Closeable
+import java.io.File
 import java.nio.file.Path
 
 class ClassProcessor(
@@ -70,11 +63,19 @@ class ClassProcessor(
 
   fun processClasses() {
     warmUpGripCaches(grip, parameters.inputs)
+
     val injectionContext = performAnalysisAndValidation()
     val providerFactory = ProviderFactoryImpl(grip.fileRegistry, parameters.projectName)
-    val generationContextFactory = GenerationContextFactory(sourceResolver, grip.fileRegistry, grip.classRegistry, providerFactory, parameters.projectName)
+
+    val generationContextFactory = GenerationContextFactory(
+      sourceResolver = sourceResolver,
+      fileRegistry = grip.fileRegistry,
+      classRegistry = grip.classRegistry,
+      providerFactory = providerFactory,
+      projectName = parameters.projectName
+    )
+
     val generationContext = generationContextFactory.createGenerationContext(injectionContext)
-    injectionContext.dump()
     copyAndPatchClasses(injectionContext, generationContext)
     performGeneration(injectionContext, generationContext)
   }
@@ -94,7 +95,25 @@ class ClassProcessor(
     val context = Analyzer(grip, errorReporter, parameters.projectName).analyze(parameters.inputs)
     val dependencyResolverFactory = DependencyResolverFactory(context)
     val hintsBuilder = HintsBuilder(grip.classRegistry)
-    Validator(grip.classRegistry, errorReporter, context, dependencyResolverFactory, hintsBuilder).validate()
+
+    if (parameters.dumpDebugReport) {
+      val report = File(parameters.reportDirectory.toFile(), "debug-dump.txt")
+
+      report.parentFile.mkdirs()
+      report.createNewFile()
+
+      FileDumpContext(report).use { dumpContext ->
+        DebugReport.dump(context, dumpContext)
+      }
+    }
+
+    Validator(
+      classRegistry = grip.classRegistry,
+      errorReporter = errorReporter,
+      context = context,
+      dependencyResolverFactory = dependencyResolverFactory,
+      hintsBuilder = hintsBuilder,
+    ).validate()
 
     if (parameters.validateUsage) {
       UsageValidator(grip, errorReporter).validateUsage(parameters.modulesClasspath)
@@ -148,86 +167,6 @@ class ClassProcessor(
   private fun checkErrors() {
     if (errorReporter.hasErrors) {
       throw ProcessingException(errorReporter.errors.joinToString(prefix = "Errors found:\n", separator = "\n"))
-    }
-  }
-
-  private fun InjectionContext.dump() {
-    if (!logger.isDebugEnabled) {
-      return
-    }
-
-    components.forEach { it.dump() }
-    contractConfigurations.forEach { it.dump() }
-    injectableTargets.forEach { it.dump("Injectable") }
-    providableTargets.forEach { it.dump("Providable") }
-  }
-
-  private fun Component.dump() {
-    logger.debug("Component: {}", type)
-    defaultModule.dump("  ")
-
-    for (subcomponent in subcomponents) {
-      logger.debug("  Subcomponent: {}", subcomponent)
-    }
-  }
-
-  private fun ContractConfiguration.dump() {
-    logger.debug("Contract Configuration: {}", type)
-    contract.dump("  ")
-    defaultModule.dump("  ")
-  }
-
-  private fun Module.dump(indent: String = "") {
-    val nextIntent = "$indent  "
-    logger.debug("${indent}Module: {}", type)
-    for (provisionPoint in provisionPoints) {
-      when (provisionPoint) {
-        is ProvisionPoint.Constructor ->
-          logger.debug("${nextIntent}Constructor: {}", provisionPoint.method)
-        is ProvisionPoint.Method ->
-          logger.debug("${nextIntent}Method: {}", provisionPoint.method)
-        is ProvisionPoint.Field ->
-          logger.debug("${nextIntent}Field: {}", provisionPoint.field)
-      }
-    }
-
-    for (binding in bindings) {
-      logger.debug("${nextIntent}Binding: {} -> {}", binding.ancestor, binding.dependency)
-    }
-
-    for (factory in factories) {
-      logger.debug("${nextIntent}Factory: {}", factory.type)
-    }
-
-    for (contract in contracts) {
-      contract.dump(nextIntent)
-    }
-
-    logger.debug("${nextIntent}Imports:")
-    val importIndent = "  $nextIntent"
-    for (import in imports) {
-      when (import) {
-        is Import.Module -> import.module.dump(importIndent)
-        is Import.Contract -> import.contract.dump(importIndent)
-      }
-    }
-  }
-
-  private fun Contract.dump(indent: String = "") {
-    val nextIntent = "$indent  "
-    logger.debug("${indent}Contract: {}", type)
-    for (provisionPoint in provisionPoints) {
-      logger.debug("${nextIntent}Method: {}", provisionPoint.method)
-    }
-  }
-
-  private fun InjectionTarget.dump(name: String) {
-    logger.debug("{}: {}", name, type)
-    for (injectionPoint in injectionPoints) {
-      when (injectionPoint) {
-        is InjectionPoint.Field -> logger.debug("  Field: {}", injectionPoint.field)
-        is InjectionPoint.Method -> logger.debug("  Method: {}", injectionPoint.method)
-      }
     }
   }
 

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/DebugReport.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/DebugReport.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.processor
+
+import com.joom.lightsaber.processor.model.Component
+import com.joom.lightsaber.processor.model.Contract
+import com.joom.lightsaber.processor.model.ContractConfiguration
+import com.joom.lightsaber.processor.model.Import
+import com.joom.lightsaber.processor.model.InjectionContext
+import com.joom.lightsaber.processor.model.InjectionPoint
+import com.joom.lightsaber.processor.model.InjectionTarget
+import com.joom.lightsaber.processor.model.Module
+import com.joom.lightsaber.processor.model.ProvisionPoint
+import com.joom.lightsaber.processor.validation.DependencyResolver
+import com.joom.lightsaber.processor.validation.DependencyResolverFactory
+import java.io.Closeable
+import java.io.File
+import java.io.PrintWriter
+import java.text.MessageFormat
+
+internal object DebugReport {
+  fun dump(injectionContext: InjectionContext, dumpContext: DumpContext) {
+    val dependencyResolverFactory = DependencyResolverFactory(injectionContext)
+    injectionContext.components.forEach { dumpContext.dump(it) }
+    injectionContext.contractConfigurations.forEach { dumpContext.dump(it, dependencyResolverFactory) }
+    injectionContext.injectableTargets.forEach { dumpContext.dump(it, "Injectable") }
+    injectionContext.providableTargets.forEach { dumpContext.dump(it, "Providable") }
+  }
+
+  private fun DumpContext.dump(component: Component) {
+    dump("Component: {}", component.type)
+    dump(component.defaultModule, "  ")
+
+    for (subcomponent in component.subcomponents) {
+      dump("  Subcomponent: {}", subcomponent)
+    }
+  }
+
+  private fun DumpContext.dump(contractConfiguration: ContractConfiguration, dependencyResolverFactory: DependencyResolverFactory) {
+    dump("Contract Configuration: {}", contractConfiguration.type)
+    dump(contractConfiguration.contract, "  ")
+    dump(contractConfiguration.defaultModule, "  ")
+    dump(dependencyResolverFactory.getOrCreate(contractConfiguration), "  ")
+  }
+
+  private fun DumpContext.dump(dependencyResolver: DependencyResolver, indent: String = "") {
+    val graph = dependencyResolver.getDependencyGraph()
+
+    val providedDependencies = dependencyResolver.getProvidedDependencies()
+    val resolvedDependencies = dependencyResolver.getResolvedDependencies()
+    val unresolvedDependencies = dependencyResolver.getUnresolvedDependencies()
+
+    if (providedDependencies.isNotEmpty()) {
+      dump("${indent}Provided dependencies:")
+      providedDependencies.keys.forEach { dependency ->
+        dump("$indent  $dependency")
+      }
+    }
+
+    if (resolvedDependencies.isNotEmpty()) {
+      dump("${indent}Resolved dependencies:")
+      resolvedDependencies.keys.forEach { dependency ->
+        dump("$indent  $dependency")
+      }
+    }
+
+    if (unresolvedDependencies.isNotEmpty()) {
+      dump("${indent}Unresolved dependencies:")
+      unresolvedDependencies.keys.forEach { dependency ->
+        dump("$indent  $dependency")
+      }
+    }
+
+    dump("${indent}Graph:")
+    graph.vertices.forEach { vertex ->
+      dump("$indent  {}", vertex)
+      graph.getAdjacentVertices(vertex)?.forEach { adjacent ->
+        dump("$indent    {}", adjacent)
+      }
+    }
+  }
+
+  private fun DumpContext.dump(module: Module, indent: String = "") {
+    val nextIntent = "$indent  "
+    dump("${indent}Module: {}", module.type)
+    for (provisionPoint in module.provisionPoints) {
+      when (provisionPoint) {
+        is ProvisionPoint.Constructor ->
+          dump("${nextIntent}Constructor: {}", provisionPoint.method)
+
+        is ProvisionPoint.Method ->
+          dump("${nextIntent}Method: {}", provisionPoint.method)
+
+        is ProvisionPoint.Field ->
+          dump("${nextIntent}Field: {}", provisionPoint.field)
+      }
+    }
+
+    for (binding in module.bindings) {
+      dump("${nextIntent}Binding: {} -> {}", binding.ancestor, binding.dependency)
+    }
+
+    for (factory in module.factories) {
+      dump("${nextIntent}Factory: {}", factory.type)
+      factory.provisionPoints.forEach { factoryProvisionPoint ->
+        dump("$nextIntent  Provision point:")
+        dump("$nextIntent    Container type: {}", factoryProvisionPoint.containerType)
+        dump("$nextIntent    Method: {}", factoryProvisionPoint.method)
+        dump("$nextIntent    Injection point container type: {}", factoryProvisionPoint.injectionPoint.containerType)
+        dump("$nextIntent    Injection point method: {}", factoryProvisionPoint.injectionPoint.method)
+        factoryProvisionPoint.injectionPoint.injectees.forEachIndexed { index, injectee ->
+          dump("$nextIntent    Injectee #{}: {}", index, injectee)
+        }
+      }
+    }
+
+    for (contract in module.contracts) {
+      dump(contract, nextIntent)
+    }
+
+    dump("${nextIntent}Imports:")
+    val importIndent = "  $nextIntent"
+    for (import in module.imports) {
+      when (import) {
+        is Import.Module -> dump(import.module, importIndent)
+        is Import.Contract -> dump(import.contract, importIndent)
+      }
+    }
+  }
+
+  private fun DumpContext.dump(contract: Contract, indent: String = "") {
+    val nextIntent = "$indent  "
+    dump("${indent}Contract: {}", contract.type)
+    for (provisionPoint in contract.provisionPoints) {
+      dump("${nextIntent}Method: {}", provisionPoint.method)
+      dump("${nextIntent}Injectee: {}", provisionPoint.injectee)
+    }
+  }
+
+  private fun DumpContext.dump(target: InjectionTarget, name: String) {
+    dump("{}: {}", name, target.type)
+    for (injectionPoint in target.injectionPoints) {
+      when (injectionPoint) {
+        is InjectionPoint.Field -> dump("  Field: {}", injectionPoint.field)
+        is InjectionPoint.Method -> dump("  Method: {}", injectionPoint.method)
+      }
+    }
+  }
+}
+
+internal interface DumpContext : Closeable {
+  fun dump(format: String, vararg args: Any?)
+}
+
+internal class FileDumpContext(
+  private val file: File
+) : DumpContext {
+  private val writer = PrintWriter(file)
+
+  override fun dump(format: String, vararg args: Any?) {
+    if (args.isNotEmpty()) {
+      writer.println(MessageFormat.format(prepareFormatArgs(format), *args))
+    } else {
+      writer.println(format)
+    }
+  }
+
+  override fun close() {
+    writer.close()
+  }
+
+  private fun prepareFormatArgs(format: String): String {
+    val parts = format.split("{}")
+
+    if (parts.size == 1) {
+      return format
+    }
+
+    return buildString {
+      parts.forEachIndexed { index, part ->
+        if (index != 0) {
+          append("{").append(index - 1).append("}")
+        }
+        append(part)
+      }
+    }
+  }
+}

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberParameters.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberParameters.kt
@@ -27,6 +27,8 @@ data class LightsaberParameters(
   val gen: Path,
   val projectName: String,
   val validateUsage: Boolean,
+  val dumpDebugReport: Boolean,
+  val reportDirectory: Path,
   val sharedBuildCache: LightsaberSharedBuildCache,
   val errorReporter: ErrorReporter = ErrorReporterImpl(),
 )

--- a/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/integration/IntegrationTestRule.kt
+++ b/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/integration/IntegrationTestRule.kt
@@ -46,6 +46,7 @@ class IntegrationTestRule(
 
   private val compiledFilesDirectory = testCaseProjectsDir.resolve("_generated")
   private val processedDirectory = testCaseProjectsDir.resolve("_processed")
+  private val reportDirectory = testCaseProjectsDir.resolve("_reports")
   private val classpath = JvmRuntimeUtil.computeRuntimeClasses()
 
   fun assertValidProject(sourceCodeDir: String) {
@@ -92,8 +93,11 @@ class IntegrationTestRule(
     modules: List<Path> = emptyList(),
     ignoreErrors: Boolean = false,
     validateUsage: Boolean = true,
+    dumpDebugReport: Boolean = false
   ): Path {
     val outputDirectory = processedDirectory.resolve(projectName)
+    val reportDirectory = reportDirectory.resolve(projectName)
+
     val parameters = LightsaberParameters(
       inputs = listOf(compiled),
       outputs = listOf(outputDirectory),
@@ -104,6 +108,8 @@ class IntegrationTestRule(
       gen = outputDirectory,
       errorReporter = errorReporter,
       validateUsage = validateUsage,
+      dumpDebugReport = dumpDebugReport,
+      reportDirectory = reportDirectory,
       sharedBuildCache = LightsaberSharedBuildCache.create(),
     )
 


### PR DESCRIPTION
This PR introduces a new `dumpDebugReport` flag that allows to dump `InjectionContext` and related information to a file. It can be useful when developing new features and it already helped me a lot to implement a new validation that detects unused contract imports (coming in a separate PR). 