### PR TITLE
AGP 8.x.x compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Run functional tests
         run: ./gradlew -p lightsaber functionalTest -Ppablo.shadow.enabled=true
 
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: functional-test-report
+          path: lightsaber/build/reports/tests/functionalTest
+
       - name: Run unit tests
         run: ./gradlew check -Pdevelopment=false -Dorg.gradle.unsafe.configuration-cache=true --stacktrace
 

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AllClassesTransformRegistrar.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/AllClassesTransformRegistrar.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.plugin
+
+import com.android.build.api.artifact.MultipleArtifact
+import com.android.build.api.variant.Component
+import org.gradle.api.tasks.TaskProvider
+
+internal object AllClassesTransformRegistrar : TransformTaskRegistrar {
+  override fun register(component: Component, taskProvider: TaskProvider<LightsaberTransformTask>) {
+    @Suppress("DEPRECATION")
+    component.artifacts.use(taskProvider)
+      .wiredWith(LightsaberTransformTask::inputDirectories, LightsaberTransformTask::outputDirectory)
+      .toTransform(MultipleArtifact.ALL_CLASSES_DIRS)
+  }
+}

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/JavaLightsaberPlugin.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/JavaLightsaberPlugin.kt
@@ -182,8 +182,8 @@ abstract class JavaLightsaberPlugin : BaseLightsaberPlugin() {
 
     return project.tasks.create(taskName, LightsaberTask::class.java) { task ->
       task.description = "Processes .class files with Lightsaber Processor."
-      task.backupDirs.from(backupDirs)
-      task.classesDirs.from(classesDirs)
+      task.inputDirectories.from(backupDirs)
+      task.outputDirectories.from(classesDirs)
       task.sourceDir.set(sourceDir)
       task.classpath.from(classpath)
       task.modulesClasspath.from(modulesClasspath)

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransform.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransform.kt
@@ -25,6 +25,7 @@ import com.android.build.api.transform.Transform
 import com.android.build.api.transform.TransformException
 import com.android.build.api.transform.TransformInvocation
 import com.android.build.api.transform.TransformOutputProvider
+import com.joom.lightsaber.processor.LightsaberOutputFactory
 import com.joom.lightsaber.processor.LightsaberParameters
 import com.joom.lightsaber.processor.LightsaberProcessor
 import com.joom.lightsaber.processor.LightsaberSharedBuildCache
@@ -60,15 +61,15 @@ class LightsaberTransform(
       )
     }
 
+    val inputPaths = inputs.map { it.file.toPath() }
     val parameters = LightsaberParameters(
-      inputs = inputs.map { it.file.toPath() },
-      outputs = outputs.map { it.toPath() },
-      gen = invocation.outputProvider.getContentLocation(
+      inputs = inputPaths,
+      outputFactory = LightsaberOutputFactory.create(inputPaths, outputs.map { it.toPath() }, invocation.outputProvider.getContentLocation(
         "gen-lightsaber",
         QualifiedContent.DefaultContentType.CLASSES,
         QualifiedContent.Scope.PROJECT,
         Format.DIRECTORY
-      ).toPath(),
+      ).toPath()),
       classpath = invocation.referencedInputs.flatMap {
         it.jarInputs.map { it.file.toPath() } + it.directoryInputs.map { it.file.toPath() }
       },

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
@@ -25,16 +25,21 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.file.Paths
@@ -46,7 +51,11 @@ abstract class LightsaberTransformTask @Inject constructor(
 ) : DefaultTask() {
   @get:InputFiles
   @get:Classpath
-  abstract val inputClasses: ListProperty<Directory>
+  abstract val inputClasses: ListProperty<RegularFile>
+
+  @get:InputFiles
+  @get:Classpath
+  abstract val inputDirectories: ListProperty<Directory>
 
   @get:InputFiles
   @get:CompileClasspath
@@ -60,7 +69,12 @@ abstract class LightsaberTransformTask @Inject constructor(
   @get:CompileClasspath
   abstract val modulesClasspath: ConfigurableFileCollection
 
+  @get:OutputFile
+  @get:Optional
+  abstract val output: RegularFileProperty
+
   @get:OutputDirectory
+  @get:Optional
   abstract val outputDirectory: DirectoryProperty
 
   @get:Internal
@@ -89,11 +103,11 @@ abstract class LightsaberTransformTask @Inject constructor(
   fun process() {
     clean()
 
-    val output = computeOutputDirectory().toPath()
+    val output = computeOutput().get().toPath()
     val reports = computeReportDirectory().toPath()
 
     val parameters = LightsaberParameters(
-      inputs = inputClasses.get().map { it.asFile.toPath() },
+      inputs = inputClasses.get().map { it.asFile.toPath() } + inputDirectories.get().map { it.asFile.toPath() },
       outputFactory = LightsaberOutputFactory.create(output),
       classpath = classpath.map { it.toPath() },
       bootClasspath = bootClasspath.map { it.toPath() },
@@ -118,11 +132,11 @@ abstract class LightsaberTransformTask @Inject constructor(
   }
 
   private fun clean() {
-    val output = computeOutputDirectory()
+    val output = computeOutput()
     val reports = computeReportDirectory()
 
-    if (output.exists()) {
-      output.deleteRecursively()
+    if (output.get().exists()) {
+      output.get().deleteRecursively()
     }
 
     if (reports.exists()) {
@@ -130,8 +144,12 @@ abstract class LightsaberTransformTask @Inject constructor(
     }
   }
 
-  private fun computeOutputDirectory(): File {
-    return outputDirectory.get().asFile
+  private fun computeOutput(): Provider<File> {
+    return when {
+      output.isPresent -> output.asFile
+      outputDirectory.isPresent -> outputDirectory.asFile
+      else -> error("output or outputDirectory is not set")
+    }
   }
 
   private fun computeReportDirectory(): File {

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/LightsaberTransformTask.kt
@@ -16,6 +16,7 @@
 
 package com.joom.lightsaber.plugin
 
+import com.joom.lightsaber.processor.LightsaberOutputFactory
 import com.joom.lightsaber.processor.LightsaberParameters
 import com.joom.lightsaber.processor.LightsaberProcessor
 import org.gradle.api.DefaultTask
@@ -93,11 +94,10 @@ abstract class LightsaberTransformTask @Inject constructor(
 
     val parameters = LightsaberParameters(
       inputs = inputClasses.get().map { it.asFile.toPath() },
-      outputs = List(inputClasses.get().size) { output },
+      outputFactory = LightsaberOutputFactory.create(output),
       classpath = classpath.map { it.toPath() },
       bootClasspath = bootClasspath.map { it.toPath() },
       modulesClasspath = modulesClasspath.map { it.toPath() },
-      gen = output,
       projectName = projectName,
       validateUsage = validateUsage.get(),
       validateUnusedImports = validateUnusedImports.get(),

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/ScopedArtifactsRegistrar.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/ScopedArtifactsRegistrar.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.plugin
+
+import com.android.build.api.artifact.ScopedArtifact
+import com.android.build.api.variant.Component
+import com.android.build.api.variant.ScopedArtifacts
+import com.android.build.api.variant.Variant
+import org.gradle.api.tasks.TaskProvider
+
+internal object ScopedArtifactsRegistrar : TransformTaskRegistrar {
+  override fun register(component: Component, taskProvider: TaskProvider<LightsaberTransformTask>) {
+    component.artifacts.forScope(ScopedArtifacts.Scope.PROJECT)
+      .use(taskProvider)
+      .toTransform(ScopedArtifact.CLASSES, LightsaberTransformTask::inputClasses, LightsaberTransformTask::inputDirectories, LightsaberTransformTask::output)
+  }
+}

--- a/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/TransformTaskRegistrar.kt
+++ b/lightsaber/gradle-plugin/src/main/java/com/joom/lightsaber/plugin/TransformTaskRegistrar.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.plugin
+
+import com.android.build.api.variant.Component
+import org.gradle.api.tasks.TaskProvider
+
+internal interface TransformTaskRegistrar {
+  fun register(component: Component, taskProvider: TaskProvider<LightsaberTransformTask>)
+}

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/FileSinkFactory.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/FileSinkFactory.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.processor
+
+import com.joom.grip.io.DirectoryFileSink
+import com.joom.grip.io.EmptyFileSink
+import com.joom.grip.io.FileSink
+import com.joom.grip.io.JarFileSink
+import java.nio.file.Path
+import java.util.Collections
+import kotlin.io.path.exists
+import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
+
+internal fun createFileSink(outputFile: Path): FileSink {
+  return when (outputFile.sourceType) {
+    FileType.EMPTY -> EmptyFileSink
+    FileType.DIRECTORY -> DirectoryFileSink(outputFile)
+    FileType.JAR -> PatchedJarFileSink(JarFileSink(outputFile))
+  }
+}
+
+private class PatchedJarFileSink(private val delegate: FileSink) : FileSink by delegate {
+  private val directories = Collections.synchronizedSet(HashSet<String>())
+
+  override fun createDirectory(path: String) {
+    if (directories.add(path)) {
+      delegate.createDirectory(path)
+    }
+  }
+}
+
+private val Path.sourceType: FileType
+  get() = when {
+    extension.endsWith("jar", ignoreCase = true) -> FileType.JAR
+    !exists() || isDirectory() -> FileType.DIRECTORY
+    else -> error("Unknown source type for file $this")
+  }
+
+private enum class FileType {
+  EMPTY,
+  DIRECTORY,
+  JAR,
+}

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberOutput.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberOutput.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.processor
+
+import com.joom.grip.io.FileSink
+import com.joom.lightsaber.processor.commons.associateByIndexedTo
+import com.joom.lightsaber.processor.commons.closeQuietly
+import java.io.Closeable
+import java.nio.file.Path
+import kotlin.math.sin
+
+interface LightsaberOutput : Closeable {
+  fun getFileSink(input: Path): FileSink
+  fun getGenerationSink(): FileSink
+}
+
+internal class MultipleSinkOutput(private val inputs: List<Path>, private val outputs: List<Path>, private val generationPath: Path) : LightsaberOutput {
+  init {
+    require(inputs.size == outputs.size) { "Inputs size should be equal to outputs size" }
+  }
+
+  private val generationSink = createFileSink(generationPath)
+  private val sinksByInputs = HashMap<Path, FileSink>().also {
+    inputs.associateByIndexedTo(it, { _, input -> input }, { index, _ -> createFileSink(outputs[index]) })
+  }
+
+  override fun getFileSink(input: Path): FileSink {
+    return sinksByInputs[input] ?: error("Failed to create file sink for input $input")
+  }
+
+  override fun getGenerationSink(): FileSink {
+    return generationSink
+  }
+
+  override fun close() {
+    generationSink.closeQuietly()
+    sinksByInputs.forEach { (_, sink) ->
+      sink.closeQuietly()
+    }
+  }
+}
+
+internal class SingleSinkOutput(path: Path) : LightsaberOutput {
+  private var sink = createFileSink(path)
+
+  override fun getFileSink(input: Path): FileSink {
+    return sink
+  }
+
+  override fun getGenerationSink(): FileSink {
+    return sink
+  }
+
+  override fun close() {
+    sink.closeQuietly()
+  }
+}

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberOutputFactory.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberOutputFactory.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.processor
+
+import java.nio.file.Path
+
+interface LightsaberOutputFactory {
+  fun createOutput(): LightsaberOutput
+
+  companion object {
+    fun create(output: Path): LightsaberOutputFactory {
+      return SingleSinkOutputProvider(output)
+    }
+
+    fun create(inputs: List<Path>, outputs: List<Path>, generationPath: Path): LightsaberOutputFactory {
+      require(inputs.size == outputs.size) { "Inputs size should be equal to outputs size" }
+
+      return MultipleSinkOutputProvider(inputs, outputs, generationPath)
+    }
+  }
+}
+
+internal class SingleSinkOutputProvider(
+  private val output: Path,
+) : LightsaberOutputFactory {
+  override fun createOutput(): LightsaberOutput {
+    return SingleSinkOutput(output)
+  }
+}
+
+internal class MultipleSinkOutputProvider(
+  private val inputs: List<Path>,
+  private val outputs: List<Path>,
+  private val generationPath: Path,
+) : LightsaberOutputFactory {
+  override fun createOutput(): LightsaberOutput {
+    return MultipleSinkOutput(inputs, outputs, generationPath)
+  }
+}
+
+

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberParameters.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/LightsaberParameters.kt
@@ -20,11 +20,10 @@ import java.nio.file.Path
 
 data class LightsaberParameters(
   val inputs: List<Path>,
-  val outputs: List<Path>,
   val classpath: List<Path>,
   val modulesClasspath: List<Path>,
   val bootClasspath: List<Path>,
-  val gen: Path,
+  val outputFactory: LightsaberOutputFactory,
   val projectName: String,
   val validateUsage: Boolean,
   val validateUnusedImports: Boolean,

--- a/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/validation/SanityChecker.kt
+++ b/lightsaber/processor/src/main/java/com/joom/lightsaber/processor/validation/SanityChecker.kt
@@ -37,7 +37,6 @@ import com.joom.lightsaber.processor.model.ImportPoint
 import com.joom.lightsaber.processor.model.InjectionContext
 import com.joom.lightsaber.processor.model.InjectionPoint
 import com.joom.lightsaber.processor.model.ProvisionPoint
-import com.joom.lightsaber.processor.reportError
 import org.objectweb.asm.Opcodes
 
 class SanityChecker(

--- a/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/MultipleSinkOutputTest.kt
+++ b/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/MultipleSinkOutputTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.processor
+
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.nio.file.Path
+
+class MultipleSinkOutputTest {
+
+  @get:Rule
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `getFileSink returns same instance per input`() {
+    val firstInput = temporaryFolder.newFile().toPath()
+    val secondInput = temporaryFolder.newFile().toPath()
+
+    createOutput(
+      inputs = listOf(firstInput, secondInput),
+    ).use { output ->
+      val firstSink = output.getFileSink(firstInput)
+      val secondSink = output.getFileSink(secondInput)
+
+      Assert.assertNotSame(firstSink, secondSink)
+      Assert.assertSame(firstSink, output.getFileSink(firstInput))
+      Assert.assertSame(secondSink, output.getFileSink(secondInput))
+    }
+  }
+
+  @Test
+  fun `getGenerationSink returns the same instance`() {
+    val path = temporaryFolder.newFolder().toPath()
+    SingleSinkOutput(path).use { output ->
+      val inputSink = output.getFileSink(temporaryFolder.newFile().toPath())
+      val generationSink = output.getGenerationSink()
+
+      Assert.assertSame(inputSink, generationSink)
+    }
+  }
+
+  private fun createOutput(inputs: List<Path>): MultipleSinkOutput {
+    return MultipleSinkOutput(
+      inputs = inputs,
+      outputs = List(inputs.size) { temporaryFolder.newFolder().toPath() },
+      generationPath = temporaryFolder.newFolder().toPath()
+    )
+  }
+}

--- a/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/SingleSinkOutputTest.kt
+++ b/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/SingleSinkOutputTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.lightsaber.processor
+
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SingleSinkOutputTest {
+
+  @get:Rule
+  val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun `getFileSink returns the same instance for different inputs`() {
+    val path = temporaryFolder.newFolder().toPath()
+    SingleSinkOutput(path).use { output ->
+      val firstSink = output.getFileSink(temporaryFolder.newFile().toPath())
+      val secondSink = output.getFileSink(temporaryFolder.newFile().toPath())
+      val thirdSink = output.getFileSink(temporaryFolder.newFile().toPath())
+
+      Assert.assertSame(firstSink, secondSink)
+      Assert.assertSame(secondSink, thirdSink)
+    }
+  }
+
+  @Test
+  fun `getGenerationSink returns the same instance`() {
+    val path = temporaryFolder.newFolder().toPath()
+    SingleSinkOutput(path).use { output ->
+      val inputSink = output.getFileSink(temporaryFolder.newFile().toPath())
+      val generationSink = output.getGenerationSink()
+
+      Assert.assertSame(inputSink, generationSink)
+    }
+  }
+}

--- a/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/integration/IntegrationTestRule.kt
+++ b/lightsaber/processor/src/test/java/com/joom/lightsaber/processor/integration/IntegrationTestRule.kt
@@ -18,6 +18,7 @@ package com.joom.lightsaber.processor.integration
 
 import com.joom.lightsaber.processor.ErrorReporter
 import com.joom.lightsaber.processor.JvmRuntimeUtil
+import com.joom.lightsaber.processor.LightsaberOutputFactory
 import com.joom.lightsaber.processor.LightsaberParameters
 import com.joom.lightsaber.processor.LightsaberProcessor
 import com.joom.lightsaber.processor.LightsaberSharedBuildCache
@@ -101,12 +102,11 @@ class IntegrationTestRule(
 
     val parameters = LightsaberParameters(
       inputs = listOf(compiled),
-      outputs = listOf(outputDirectory),
+      outputFactory = LightsaberOutputFactory.create(outputDirectory),
       bootClasspath = classpath,
       modulesClasspath = modules,
       classpath = emptyList(),
       projectName = projectName,
-      gen = outputDirectory,
       errorReporter = errorReporter,
       validateUsage = validateUsage,
       validateUnusedImports = validateUnusedImports,

--- a/lightsaber/src/functionalTest/java/com/joom/lightsaber/plugin/AndroidLightsaberPluginTest.kt
+++ b/lightsaber/src/functionalTest/java/com/joom/lightsaber/plugin/AndroidLightsaberPluginTest.kt
@@ -43,6 +43,7 @@ internal class AndroidLightsaberPluginTest(private val case: TestCase) {
       return listOf(
         TestCase(agpVersion = "7.0.4", GradleDistribution.GRADLE_7_5, expectedTaskName = ":transformClassesWithLightsaberForDebug"),
         TestCase(agpVersion = "7.2.0", GradleDistribution.GRADLE_7_5, expectedTaskName = ":lightsaberTransformClassesDebug"),
+        TestCase(agpVersion = "8.0.2", GradleDistribution.GRADLE_8_0, expectedTaskName = ":lightsaberTransformClassesDebug"),
       )
     }
 


### PR DESCRIPTION
Introduced `LightsaberOutput` that hides discrepancies among inputs / outputs of different transformation APIs.

At the moment plugin supports 3 transformation APIs:
1. Legacy Transform API (no longer supported in AGP 8.0.0, but still binary compatible)
2. `MultipleArtifact.ALL_CLASSES_DIRS` transformation API (Completely removed from AGP 8.0.0)
4. Latest transformation API `ScopedArtifact.CLASSES`
